### PR TITLE
Added Support for `quiltFabricModule` and `qslModule` calls

### DIFF
--- a/src/api/kotlin/xyz/wagyourtail/unimined/api/minecraft/patch/fabric/FabricLikeApiExtension.kt
+++ b/src/api/kotlin/xyz/wagyourtail/unimined/api/minecraft/patch/fabric/FabricLikeApiExtension.kt
@@ -47,24 +47,6 @@ open class FabricLikeApiExtension {
     }
 
     val locations = mapOf<String, APILocations>(
-        "quilt" to object : APILocations() {
-            override fun getUrl(version: String): String {
-                return "https://maven.quiltmc.org/repository/release/org/quiltmc/quilted-fabric-api/quilted-fabric-api/$version/quilted-fabric-api-$version.pom"
-            }
-
-            override fun getArtifactName(moduleName: String, version: String?): String {
-                return "org.quiltmc.quilted-fabric-api:$moduleName:$version"
-            } 
-        },
-        "qsl" to object : APILocations() {
-            override fun getUrl(version: String): String {
-                return "https://maven.quiltmc.org/repository/release/org/quiltmc/qsl/$version/qsl-$version.pom"
-            }
-
-            override fun getArtifactName(moduleName: String, version: String?): String {
-                return "org.quiltmc.qsl:$moduleName:$version"
-            } 
-        },
         "fabric" to object : APILocations() {
             override fun getUrl(version: String): String {
                 return "https://maven.fabricmc.net/net/fabricmc/fabric-api/fabric-api/$version/fabric-api-$version.pom"
@@ -82,6 +64,24 @@ open class FabricLikeApiExtension {
             override fun getArtifactName(moduleName: String, version: String?): String {
                 return "net.legacyfabric.legacy-fabric-api:$moduleName:$version"
             }
+        },
+        "quilt" to object : APILocations() {
+            override fun getUrl(version: String): String {
+                return "https://maven.quiltmc.org/repository/release/org/quiltmc/quilted-fabric-api/quilted-fabric-api/$version/quilted-fabric-api-$version.pom"
+            }
+
+            override fun getArtifactName(moduleName: String, version: String?): String {
+                return "org.quiltmc.quilted-fabric-api:$moduleName:$version"
+            } 
+        },
+        "qsl" to object : APILocations() {
+            override fun getUrl(version: String): String {
+                return "https://maven.quiltmc.org/repository/release/org/quiltmc/qsl/$version/qsl-$version.pom"
+            }
+
+            override fun getArtifactName(moduleName: String, version: String?): String {
+                return "org.quiltmc.qsl:$moduleName:$version"
+            } 
         }
     )
 
@@ -121,7 +121,5 @@ open class FabricLikeApiExtension {
     fun legacyFabricModule(moduleName: String, version: String): String {
         return locations["legacyFabric"]!!.module(moduleName, version) ?: throw IllegalStateException("Could not find module $moduleName:$version")
     }
-
-    //TODO: figure out quilted fabric / qsl, would then want to rename extension from fabricApi
 
 }

--- a/src/api/kotlin/xyz/wagyourtail/unimined/api/minecraft/patch/fabric/FabricLikeApiExtension.kt
+++ b/src/api/kotlin/xyz/wagyourtail/unimined/api/minecraft/patch/fabric/FabricLikeApiExtension.kt
@@ -47,6 +47,24 @@ open class FabricLikeApiExtension {
     }
 
     val locations = mapOf<String, APILocations>(
+        "quilt" to object : APILocations() {
+            override fun getUrl(version: String): String {
+                return "https://maven.quiltmc.org/repository/release/org/quiltmc/quilted-fabric-api/quilted-fabric-api/$version/quilted-fabric-api-$version.pom"
+            }
+
+            override fun getArtifactName(moduleName: String, version: String?): String {
+                return "org.quiltmc.quilted-fabric-api:$moduleName:$version"
+            } 
+        },
+        "qsl" to object : APILocations() {
+            override fun getUrl(version: String): String {
+                return "https://maven.quiltmc.org/repository/release/org/quiltmc/qsl/$version/qsl-$version.pom"
+            }
+
+            override fun getArtifactName(moduleName: String, version: String?): String {
+                return "org.quiltmc.qsl:$moduleName:$version"
+            } 
+        },
         "fabric" to object : APILocations() {
             override fun getUrl(version: String): String {
                 return "https://maven.fabricmc.net/net/fabricmc/fabric-api/fabric-api/$version/fabric-api-$version.pom"
@@ -78,6 +96,22 @@ open class FabricLikeApiExtension {
      */
     fun fabricModule(moduleName: String, version: String): String {
         return locations["fabric"]!!.module(moduleName, version) ?: throw IllegalStateException("Could not find module $moduleName:$version")
+    }
+
+
+    /**
+     * @since 1.0.0
+     */
+    fun quiltFabricModule(moduleName: String, version: String): String {
+        return locations["quilt"]!!.module(moduleName, version) ?: throw IllegalStateException("Could not find module $moduleName:$version")
+    }
+
+
+    /**
+     * @since 1.0.0
+     */
+    fun qslModule(moduleName: String, version: String): String {
+        return locations["qsl"]!!.module(moduleName, version) ?: throw IllegalStateException("Could not find module $moduleName:$version")
     }
 
 


### PR DESCRIPTION
Examples (Taken from CraftPresence prototype):

```
    // Quilt Integrations
    // QSL - Required for Mod Loading
    modImplementation(fabricApi.qsl("core", qsl_version))
    // Required for loading translation data
    modImplementation(fabricApi.quiltFabricModule("fabric-resource-loader-v0", quilted_fabric_api_version))
    include(fabricApi.quiltFabricModule("fabric-resource-loader-v0", quilted_fabric_api_version))
```