### PR TITLE
Don't read non-existent classpaths

### DIFF
--- a/src/minecraft/kotlin/xyz/wagyourtail/unimined/internal/minecraft/MinecraftRemapper.kt
+++ b/src/minecraft/kotlin/xyz/wagyourtail/unimined/internal/minecraft/MinecraftRemapper.kt
@@ -116,7 +116,7 @@ class MinecraftRemapper(val project: Project, val provider: MinecraftProvider): 
         }
         tinyRemapperConf(remapperB)
         val remapper = remapperB.build()
-        remapper.readClassPathAsync(*provider.minecraftLibraries.files.map { it.toPath() }.toTypedArray())
+        remapper.readClassPathAsync(*provider.minecraftLibraries.files.map { it.toPath() }.filter { it.exists() }.toTypedArray())
         try {
             remapper.readInputsAsync(from)
             OutputConsumerPath.Builder(target).build().use {


### PR DESCRIPTION
Gradle doesn't create a `build/resources` dir if a sourceset doesn't contain resources