### PR TITLE
Improve and Fix Integration tests

### DIFF
--- a/.github/workflows/test-push.yml
+++ b/.github/workflows/test-push.yml
@@ -11,7 +11,20 @@ jobs:
       fail-fast: false
       matrix:
         # Update when https://github.com/gradle/gradle/issues/25609 is fixed
-        version: [8.1.0]
+        gradle: [
+          7.6.3, # minimal supported version
+          8.1, # middle ground
+          8.4, # version used by buildscript
+          8 # latest
+        ]
+        java: [
+          8, # Old LTS
+          11, # Should we even test this one?
+          17, # LTS
+        ]
+        includes:
+          - gradle: 8
+            java: 21 # Latest LTS only supported by gradle 8.5+
     runs-on: ubuntu-22.04
     container:
       image: gradle:${{ matrix.version }}-jdk17
@@ -19,7 +32,10 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: gradle/wrapper-validation-action@v1
-      - run: gradle build check -x test --stacktrace --warning-mode fail
+      - if: ${{ matrix.gradle == "8.1" && matrix.java == 17 }}
+        run: gradle build check -x test --stacktrace --warning-mode fail
+      - if: ${{ matrix.gradle != "8.1" || matrix.java != 17 }}
+        run: gradle build check -x test --stacktrace
 
   # This job is used to feed the test matrix of next job to allow the tests to run in parallel
   prepare_test_matrix:

--- a/.github/workflows/test-push.yml
+++ b/.github/workflows/test-push.yml
@@ -10,10 +10,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        version: [8.1.0-jdk17]
+        # Update when https://github.com/gradle/gradle/issues/25609 is fixed
+        version: [8.1.0]
     runs-on: ubuntu-22.04
     container:
-      image: gradle:${{ matrix.version }}
+      image: gradle:${{ matrix.version }}-jdk17
       options: --user root
     steps:
       - uses: actions/checkout@v3
@@ -27,12 +28,12 @@ jobs:
 
     runs-on: ubuntu-22.04
     container:
-      image: gradle:8.1.0-jdk17
+      image: gradle:8.4.0-jdk17
       options: --user root
 
     steps:
       - uses: actions/checkout@v3
-      - run: gradle writeActionsTestMatrix --stacktrace --warning-mode fail
+      - run: gradle writeActionsTestMatrix --stacktrace
       -
         id: set-matrix
         run: echo "matrix=$(cat build/test_matrix.json)" >> $GITHUB_OUTPUT
@@ -46,17 +47,19 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        version: [8.1.0-jdk17]
+        # Update when https://github.com/gradle/gradle/issues/25609 is fixed
+        gradle: [8.1.0]
+        java: [17]
         test: ${{ fromJson(needs.prepare_test_matrix.outputs.matrix) }}
 
     runs-on: ubuntu-22.04
     container:
-      image: gradle:${{ matrix.version }}
+      image: gradle:${{ matrix.gradle }}-jdk${{ matrix.java }}
       options: --user root
 
     steps:
       - uses: actions/checkout@v3
-      - run: gradle test --tests ${{ matrix.test }} --stacktrace --warning-mode fail
+      - run: gradle test --tests ${{ matrix.test }}
         env:
           TEST_WARNING_MODE: fail
         id: test
@@ -90,7 +93,7 @@ jobs:
         with:
           java-version: ${{ matrix.java }}
           distribution: 'temurin'
-      - run: ./gradlew test --tests ${{ matrix.test }} --stacktrace --warning-mode fail
+      - run: ./gradlew test --tests ${{ matrix.test }}
         env:
           TEST_WARNING_MODE: fail
         id: test

--- a/.github/workflows/test-push.yml
+++ b/.github/workflows/test-push.yml
@@ -21,7 +21,7 @@ jobs:
           11, # Should we even test this one?
           17 # LTS
         ]
-        includes:
+        include:
           - gradle: 8
             java: 21 # Latest LTS only supported by gradle 8.5+
     runs-on: ubuntu-22.04

--- a/.github/workflows/test-push.yml
+++ b/.github/workflows/test-push.yml
@@ -27,7 +27,7 @@ jobs:
 #            java: 21 # Latest LTS only supported by gradle 8.5+
     runs-on: ubuntu-22.04
     container:
-      image: gradle:${{ matrix.version }}-jdk17
+      image: gradle:${{ matrix.gradle }}-jdk${{ matrix.java }}
       options: --user root
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/test-push.yml
+++ b/.github/workflows/test-push.yml
@@ -32,9 +32,9 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: gradle/wrapper-validation-action@v1
-      - if: ${{ matrix.gradle == "8.1" && matrix.java == 17 }}
+      - if: ${{ matrix.gradle == '8.1' && matrix.java == 17 }}
         run: gradle build check -x test --stacktrace --warning-mode fail
-      - if: ${{ matrix.gradle != "8.1" || matrix.java != 17 }}
+      - if: ${{ matrix.gradle != '8.1' || matrix.java != 17 }}
         run: gradle build check -x test --stacktrace
 
   # This job is used to feed the test matrix of next job to allow the tests to run in parallel

--- a/.github/workflows/test-push.yml
+++ b/.github/workflows/test-push.yml
@@ -10,7 +10,6 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # Update when https://github.com/gradle/gradle/issues/25609 is fixed
         gradle: [
           7.6.3, # minimal supported version
           8.1, # middle ground
@@ -20,11 +19,11 @@ jobs:
         java: [
           8, # Old LTS
           11, # Should we even test this one?
-          17, # LTS
+          17 # LTS
         ]
-#        includes:
-#          - gradle: 8
-#            java: 21 # Latest LTS only supported by gradle 8.5+
+        includes:
+          - gradle: 8
+            java: 21 # Latest LTS only supported by gradle 8.5+
     runs-on: ubuntu-22.04
     container:
       image: gradle:${{ matrix.gradle }}-jdk${{ matrix.java }}
@@ -32,6 +31,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: gradle/wrapper-validation-action@v1
+        # Update when https://github.com/gradle/gradle/issues/25609 is fixed
       - if: ${{ matrix.gradle == '8.1' && matrix.java == 17 }}
         run: gradle build check -x test --stacktrace --warning-mode fail
       - if: ${{ matrix.gradle != '8.1' || matrix.java != 17 }}
@@ -64,7 +64,7 @@ jobs:
       fail-fast: false
       matrix:
         # Update when https://github.com/gradle/gradle/issues/25609 is fixed
-        gradle: [8.1.0]
+        gradle: [8.4.0]
         java: [17]
         test: ${{ fromJson(needs.prepare_test_matrix.outputs.matrix) }}
 

--- a/.github/workflows/test-push.yml
+++ b/.github/workflows/test-push.yml
@@ -11,19 +11,21 @@ jobs:
       fail-fast: false
       matrix:
         gradle: [
-          7.6.3, # minimal supported version
-          8.1, # middle ground
+          8.1,
           8.4, # version used by buildscript
           8 # latest
         ]
         java: [
           8, # Old LTS
           11, # Should we even test this one?
-          17 # LTS
+          17, # LTS
+          21 # Latest LTS only supported by gradle 8.5+
         ]
-        include:
-          - gradle: 8
-            java: 21 # Latest LTS only supported by gradle 8.5+
+        exclude:
+          - gradle: 8.1
+            java: 21
+          - gradle: 8.4
+            java: 21
     runs-on: ubuntu-22.04
     container:
       image: gradle:${{ matrix.gradle }}-jdk${{ matrix.java }}
@@ -63,14 +65,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # Update when https://github.com/gradle/gradle/issues/25609 is fixed
-        gradle: [8.4.0]
         java: [17]
         test: ${{ fromJson(needs.prepare_test_matrix.outputs.matrix) }}
 
     runs-on: ubuntu-22.04
     container:
-      image: gradle:${{ matrix.gradle }}-jdk${{ matrix.java }}
+      image: gradle:8.4-jdk${{ matrix.java }}
       options: --user root
 
     steps:

--- a/.github/workflows/test-push.yml
+++ b/.github/workflows/test-push.yml
@@ -22,9 +22,9 @@ jobs:
           11, # Should we even test this one?
           17, # LTS
         ]
-        includes:
-          - gradle: 8
-            java: 21 # Latest LTS only supported by gradle 8.5+
+#        includes:
+#          - gradle: 8
+#            java: 21 # Latest LTS only supported by gradle 8.5+
     runs-on: ubuntu-22.04
     container:
       image: gradle:${{ matrix.version }}-jdk17

--- a/.github/workflows/test-push.yml
+++ b/.github/workflows/test-push.yml
@@ -56,7 +56,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-      - run: gradle test --tests ${{ matrix.test }} --stacktrace --info --warning-mode fail
+      - run: gradle test --tests ${{ matrix.test }} --stacktrace --warning-mode fail
         env:
           TEST_WARNING_MODE: fail
         id: test
@@ -90,7 +90,7 @@ jobs:
         with:
           java-version: ${{ matrix.java }}
           distribution: 'temurin'
-      - run: ./gradlew test --tests ${{ matrix.test }} --stacktrace --info --warning-mode fail
+      - run: ./gradlew test --tests ${{ matrix.test }} --stacktrace --warning-mode fail
         env:
           TEST_WARNING_MODE: fail
         id: test

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -179,6 +179,9 @@ dependencies {
     compileOnly("org.jetbrains.kotlinx:kotlinx-metadata-jvm:0.4.2") {
         isTransitive = false
     }
+
+    testImplementation("org.junit.jupiter:junit-jupiter:5.6.3")
+    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
 }
 
 tasks.jar {

--- a/src/test/kotlin/xyz/wagyourtail/unimined/test/integration/BabricModloaderB1_7_3Test.kt
+++ b/src/test/kotlin/xyz/wagyourtail/unimined/test/integration/BabricModloaderB1_7_3Test.kt
@@ -2,14 +2,16 @@ package xyz.wagyourtail.unimined.test.integration
 
 import org.gradle.testkit.runner.TaskOutcome
 import org.gradle.testkit.runner.UnexpectedBuildFailure
-import org.junit.jupiter.api.Test
-import xyz.wagyourtail.unimined.util.runTestProject
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.MethodSource
+import xyz.wagyourtail.unimined.util.*
 
 class BabricModloaderB1_7_3Test {
-    @Test
-    fun test_babric_modloader_b1_7_3() {
+    @ParameterizedTest
+    @MethodSource("xyz.wagyourtail.unimined.util.IntegrationTestUtils#versions")
+    fun test_babric_modloader_b1_7_3(gradleVersion: String) {
         try {
-            val result = runTestProject("b1.7.3-Babric-Modloader")
+            val result = runTestProject("b1.7.3-Babric-Modloader", gradleVersion)
 
             try {
                 result.task(":build")?.outcome?.let {

--- a/src/test/kotlin/xyz/wagyourtail/unimined/test/integration/FabricInterfaceInjectionTest.kt
+++ b/src/test/kotlin/xyz/wagyourtail/unimined/test/integration/FabricInterfaceInjectionTest.kt
@@ -3,6 +3,8 @@ package xyz.wagyourtail.unimined.test.integration
 import org.gradle.testkit.runner.TaskOutcome
 import org.gradle.testkit.runner.UnexpectedBuildFailure
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.MethodSource
 import org.objectweb.asm.ClassReader
 import org.objectweb.asm.Opcodes
 import org.objectweb.asm.tree.ClassNode
@@ -13,11 +15,12 @@ import kotlin.io.path.inputStream
 import kotlin.test.*
 
 class FabricInterfaceInjectionTest {
-    @Test
-    fun test_fabric_interface_injection() {
+    @ParameterizedTest
+    @MethodSource("xyz.wagyourtail.unimined.util.IntegrationTestUtils#versions")
+    fun test_fabric_interface_injection(gradleVersion: String) {
         val projectName = "Fabric-Interface-Injection"
         try {
-            val result = runTestProject(projectName)
+            val result = runTestProject(projectName, gradleVersion)
 
             try {
                 result.task(":build")?.outcome?.let {

--- a/src/test/kotlin/xyz/wagyourtail/unimined/test/integration/Forge1_3_2Test.kt
+++ b/src/test/kotlin/xyz/wagyourtail/unimined/test/integration/Forge1_3_2Test.kt
@@ -3,13 +3,16 @@ package xyz.wagyourtail.unimined.test.integration
 import org.gradle.testkit.runner.TaskOutcome
 import org.gradle.testkit.runner.UnexpectedBuildFailure
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.MethodSource
 import xyz.wagyourtail.unimined.util.runTestProject
 
 class Forge1_3_2Test {
-    @Test
-    fun test_forge_1_3_2() {
+    @ParameterizedTest
+    @MethodSource("xyz.wagyourtail.unimined.util.IntegrationTestUtils#versions")
+    fun test_forge_1_3_2(gradleVersion: String) {
         try {
-            val result = runTestProject("1.3.2-Forge")
+            val result = runTestProject("1.3.2-Forge", gradleVersion)
 
             try {
                 result.task(":build")?.outcome?.let {

--- a/src/test/kotlin/xyz/wagyourtail/unimined/test/integration/Forge1_6_4Test.kt
+++ b/src/test/kotlin/xyz/wagyourtail/unimined/test/integration/Forge1_6_4Test.kt
@@ -3,13 +3,16 @@ package xyz.wagyourtail.unimined.test.integration
 import org.gradle.testkit.runner.TaskOutcome
 import org.gradle.testkit.runner.UnexpectedBuildFailure
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.MethodSource
 import xyz.wagyourtail.unimined.util.runTestProject
 
 class Forge1_6_4Test {
-    @Test
-    fun test_forge_1_6_4() {
+    @ParameterizedTest
+    @MethodSource("xyz.wagyourtail.unimined.util.IntegrationTestUtils#versions")
+    fun test_forge_1_6_4(gradleVersion: String) {
         try {
-            val result = runTestProject("1.6.4-Forge")
+            val result = runTestProject("1.6.4-Forge", gradleVersion)
 
             try {
                 result.task(":build")?.outcome?.let {

--- a/src/test/kotlin/xyz/wagyourtail/unimined/test/integration/ForgeFabric1_12_2Test.kt
+++ b/src/test/kotlin/xyz/wagyourtail/unimined/test/integration/ForgeFabric1_12_2Test.kt
@@ -3,13 +3,16 @@ package xyz.wagyourtail.unimined.test.integration
 import org.gradle.testkit.runner.TaskOutcome
 import org.gradle.testkit.runner.UnexpectedBuildFailure
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.MethodSource
 import xyz.wagyourtail.unimined.util.runTestProject
 
 class ForgeFabric1_12_2Test {
-    @Test
-    fun test_forge_fabric_1_12_2() {
+    @ParameterizedTest
+    @MethodSource("xyz.wagyourtail.unimined.util.IntegrationTestUtils#versions")
+    fun test_forge_fabric_1_12_2(gradleVersion: String) {
         try {
-            val result = runTestProject("1.12.2-Forge-Fabric")
+            val result = runTestProject("1.12.2-Forge-Fabric", gradleVersion)
 
             try {
                 result.task(":build")?.outcome?.let {

--- a/src/test/kotlin/xyz/wagyourtail/unimined/test/integration/ForgeFabric1_14_4Test.kt
+++ b/src/test/kotlin/xyz/wagyourtail/unimined/test/integration/ForgeFabric1_14_4Test.kt
@@ -3,13 +3,16 @@ package xyz.wagyourtail.unimined.test.integration
 import org.gradle.testkit.runner.TaskOutcome
 import org.gradle.testkit.runner.UnexpectedBuildFailure
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.MethodSource
 import xyz.wagyourtail.unimined.util.runTestProject
 
 class ForgeFabric1_14_4Test {
-    @Test
-    fun test_forge_fabric_1_14_4() {
+    @ParameterizedTest
+    @MethodSource("xyz.wagyourtail.unimined.util.IntegrationTestUtils#versions")
+    fun test_forge_fabric_1_14_4(gradleVersion: String) {
         try {
-            val result = runTestProject("1.14.4-Forge-Fabric")
+            val result = runTestProject("1.14.4-Forge-Fabric", gradleVersion)
 
             try {
                 result.task(":build")?.outcome?.let {

--- a/src/test/kotlin/xyz/wagyourtail/unimined/test/integration/ForgeFabric1_15_2Test.kt
+++ b/src/test/kotlin/xyz/wagyourtail/unimined/test/integration/ForgeFabric1_15_2Test.kt
@@ -3,13 +3,16 @@ package xyz.wagyourtail.unimined.test.integration
 import org.gradle.testkit.runner.TaskOutcome
 import org.gradle.testkit.runner.UnexpectedBuildFailure
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.MethodSource
 import xyz.wagyourtail.unimined.util.runTestProject
 
 class ForgeFabric1_15_2Test {
-    @Test
-    fun test_forge_fabric_1_15_2() {
+    @ParameterizedTest
+    @MethodSource("xyz.wagyourtail.unimined.util.IntegrationTestUtils#versions")
+    fun test_forge_fabric_1_15_2(gradleVersion: String) {
         try {
-            val result = runTestProject("1.15.2-Forge-Fabric")
+            val result = runTestProject("1.15.2-Forge-Fabric", gradleVersion)
 
             try {
                 result.task(":build")?.outcome?.let {

--- a/src/test/kotlin/xyz/wagyourtail/unimined/test/integration/ForgeFabric1_16_5Test.kt
+++ b/src/test/kotlin/xyz/wagyourtail/unimined/test/integration/ForgeFabric1_16_5Test.kt
@@ -3,13 +3,16 @@ package xyz.wagyourtail.unimined.test.integration
 import org.gradle.testkit.runner.TaskOutcome
 import org.gradle.testkit.runner.UnexpectedBuildFailure
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.MethodSource
 import xyz.wagyourtail.unimined.util.runTestProject
 
 class ForgeFabric1_16_5Test {
-    @Test
-    fun test_forge_fabric_1_16_5() {
+    @ParameterizedTest
+    @MethodSource("xyz.wagyourtail.unimined.util.IntegrationTestUtils#versions")
+    fun test_forge_fabric_1_16_5(gradleVersion: String) {
         try {
-            val result = runTestProject("1.16.5-Forge-Fabric")
+            val result = runTestProject("1.16.5-Forge-Fabric", gradleVersion)
 
             try {
                 result.task(":build")?.outcome?.let {

--- a/src/test/kotlin/xyz/wagyourtail/unimined/test/integration/ForgeFabric1_17_1Test.kt
+++ b/src/test/kotlin/xyz/wagyourtail/unimined/test/integration/ForgeFabric1_17_1Test.kt
@@ -3,13 +3,16 @@ package xyz.wagyourtail.unimined.test.integration
 import org.gradle.testkit.runner.TaskOutcome
 import org.gradle.testkit.runner.UnexpectedBuildFailure
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.MethodSource
 import xyz.wagyourtail.unimined.util.runTestProject
 
 class ForgeFabric1_17_1Test {
-    @Test
-    fun test_forge_fabric_1_17_1() {
+    @ParameterizedTest
+    @MethodSource("xyz.wagyourtail.unimined.util.IntegrationTestUtils#versions")
+    fun test_forge_fabric_1_17_1(gradleVersion: String) {
         try {
-            val result = runTestProject("1.17.1-Forge-Fabric")
+            val result = runTestProject("1.17.1-Forge-Fabric", gradleVersion)
 
             try {
                 result.task(":build")?.outcome?.let {

--- a/src/test/kotlin/xyz/wagyourtail/unimined/test/integration/ForgeFabric1_20Test.kt
+++ b/src/test/kotlin/xyz/wagyourtail/unimined/test/integration/ForgeFabric1_20Test.kt
@@ -4,14 +4,17 @@ import org.gradle.testkit.runner.TaskOutcome
 import org.gradle.testkit.runner.UnexpectedBuildFailure
 import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.MethodSource
 import xyz.wagyourtail.unimined.util.runTestProject
 
 class ForgeFabric1_20Test {
-    @Test
+    @ParameterizedTest
+    @MethodSource("xyz.wagyourtail.unimined.util.IntegrationTestUtils#versions")
     @Disabled
-    fun test_forge_fabric_1_20() {
+    fun test_forge_fabric_1_20(gradleVersion: String) {
         try {
-            val result = runTestProject("1.20-Forge-Fabric")
+            val result = runTestProject("1.20-Forge-Fabric", gradleVersion)
 
             try {
                 result.task(":build")?.outcome?.let {

--- a/src/test/kotlin/xyz/wagyourtail/unimined/test/integration/ForgeFabric1_7_10Test.kt
+++ b/src/test/kotlin/xyz/wagyourtail/unimined/test/integration/ForgeFabric1_7_10Test.kt
@@ -3,13 +3,16 @@ package xyz.wagyourtail.unimined.test.integration
 import org.gradle.testkit.runner.TaskOutcome
 import org.gradle.testkit.runner.UnexpectedBuildFailure
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.MethodSource
 import xyz.wagyourtail.unimined.util.runTestProject
 
 class ForgeFabric1_7_10Test {
-    @Test
-    fun test_forge_fabric_1_7_10() {
+    @ParameterizedTest
+    @MethodSource("xyz.wagyourtail.unimined.util.IntegrationTestUtils#versions")
+    fun test_forge_fabric_1_7_10(gradleVersion: String) {
         try {
-            val result = runTestProject("1.7.10-Forge-Fabric")
+            val result = runTestProject("1.7.10-Forge-Fabric", gradleVersion)
 
             try {
                 result.task(":build")?.outcome?.let {

--- a/src/test/kotlin/xyz/wagyourtail/unimined/test/integration/ForgeFabric1_8_9Test.kt
+++ b/src/test/kotlin/xyz/wagyourtail/unimined/test/integration/ForgeFabric1_8_9Test.kt
@@ -3,13 +3,16 @@ package xyz.wagyourtail.unimined.test.integration
 import org.gradle.testkit.runner.TaskOutcome
 import org.gradle.testkit.runner.UnexpectedBuildFailure
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.MethodSource
 import xyz.wagyourtail.unimined.util.runTestProject
 
 class ForgeFabric1_8_9Test {
-    @Test
-    fun test_forge_fabric_1_8_9() {
+    @ParameterizedTest
+    @MethodSource("xyz.wagyourtail.unimined.util.IntegrationTestUtils#versions")
+    fun test_forge_fabric_1_8_9(gradleVersion: String) {
         try {
-            val result = runTestProject("1.8.9-Forge-Fabric")
+            val result = runTestProject("1.8.9-Forge-Fabric", gradleVersion)
 
             try {
                 result.task(":build")?.outcome?.let {

--- a/src/test/kotlin/xyz/wagyourtail/unimined/test/integration/ForgeModloader1_2_5Test.kt
+++ b/src/test/kotlin/xyz/wagyourtail/unimined/test/integration/ForgeModloader1_2_5Test.kt
@@ -3,13 +3,16 @@ package xyz.wagyourtail.unimined.test.integration
 import org.gradle.testkit.runner.TaskOutcome
 import org.gradle.testkit.runner.UnexpectedBuildFailure
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.MethodSource
 import xyz.wagyourtail.unimined.util.runTestProject
 
 class ForgeModloader1_2_5Test {
-    @Test
-    fun test_forge_modloader_1_2_5() {
+    @ParameterizedTest
+    @MethodSource("xyz.wagyourtail.unimined.util.IntegrationTestUtils#versions")
+    fun test_forge_modloader_1_2_5(gradleVersion: String) {
         try {
-            val result = runTestProject("1.2.5-Forge-Modloader")
+            val result = runTestProject("1.2.5-Forge-Modloader", gradleVersion)
 
             try {
                 result.task(":build")?.outcome?.let {

--- a/src/test/kotlin/xyz/wagyourtail/unimined/test/integration/NeoForgedFabric1_20_1Test.kt
+++ b/src/test/kotlin/xyz/wagyourtail/unimined/test/integration/NeoForgedFabric1_20_1Test.kt
@@ -3,13 +3,16 @@ package xyz.wagyourtail.unimined.test.integration
 import org.gradle.testkit.runner.TaskOutcome
 import org.gradle.testkit.runner.UnexpectedBuildFailure
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.MethodSource
 import xyz.wagyourtail.unimined.util.runTestProject
 
 class NeoForgedFabric1_20_1Test {
-    @Test
-    fun test_neoforged_fabric_1_20_1() {
+    @ParameterizedTest
+    @MethodSource("xyz.wagyourtail.unimined.util.IntegrationTestUtils#versions")
+    fun test_neoforged_fabric_1_20_1(gradleVersion: String) {
         try {
-            val result = runTestProject("1.20.1-NeoForged-Fabric")
+            val result = runTestProject("1.20.1-NeoForged-Fabric", gradleVersion)
 
             try {
                 result.task(":build")?.outcome?.let {

--- a/src/test/kotlin/xyz/wagyourtail/unimined/test/integration/NeoForgedForgeFabric1_20_2Test.kt
+++ b/src/test/kotlin/xyz/wagyourtail/unimined/test/integration/NeoForgedForgeFabric1_20_2Test.kt
@@ -3,13 +3,16 @@ package xyz.wagyourtail.unimined.test.integration
 import org.gradle.testkit.runner.TaskOutcome
 import org.gradle.testkit.runner.UnexpectedBuildFailure
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.MethodSource
 import xyz.wagyourtail.unimined.util.runTestProject
 
 class NeoForgedForgeFabric1_20_2Test {
-    @Test
-    fun test_neoforged_fabric_1_20_2() {
+    @ParameterizedTest
+    @MethodSource("xyz.wagyourtail.unimined.util.IntegrationTestUtils#versions")
+    fun test_neoforged_fabric_1_20_2(gradleVersion: String) {
         try {
-            val result = runTestProject("1.20.2-NeoForged-Forge-Fabric")
+            val result = runTestProject("1.20.2-NeoForged-Forge-Fabric", gradleVersion)
 
             try {
                 result.task(":build")?.outcome?.let {

--- a/src/test/kotlin/xyz/wagyourtail/unimined/test/integration/NeoForgedForgeFabric1_20_3Test.kt
+++ b/src/test/kotlin/xyz/wagyourtail/unimined/test/integration/NeoForgedForgeFabric1_20_3Test.kt
@@ -3,18 +3,16 @@ package xyz.wagyourtail.unimined.test.integration
 import org.gradle.testkit.runner.TaskOutcome
 import org.gradle.testkit.runner.UnexpectedBuildFailure
 import org.junit.jupiter.api.Disabled
-import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.MethodSource
 import xyz.wagyourtail.unimined.util.runTestProject
 
-class ForgeFabric1_20Test {
+class NeoForgedForgeFabric1_20_3Test {
     @ParameterizedTest
     @MethodSource("xyz.wagyourtail.unimined.util.IntegrationTestUtils#versions")
-    @Disabled
-    fun test_forge_fabric_1_20(gradleVersion: String) {
+    fun test_neoforged_forge_fabric_1_20_3(gradleVersion: String) {
         try {
-            val result = runTestProject("1.20-Forge-Fabric", gradleVersion)
+            val result = runTestProject("1.20.3-NeoForged-Forge-Fabric", gradleVersion)
 
             try {
                 result.task(":build")?.outcome?.let {

--- a/src/test/kotlin/xyz/wagyourtail/unimined/util/IntegrationTestUtils.kt
+++ b/src/test/kotlin/xyz/wagyourtail/unimined/util/IntegrationTestUtils.kt
@@ -29,11 +29,12 @@ fun openZipFileSystem(project: String, path: String): FileSystem? {
 }
 class IntegrationTestUtils {
     companion object {
-        val GRADLE_VERSION = arrayOf(
+        private val GRADLE_VERSION = arrayOf(
 //            "7.6.3",
             "8.1.1",
+            "8.4",
+            "8.5",
             GRADLE_CURRENT,
-            "8.5"
         )
 
         @JvmStatic

--- a/src/test/kotlin/xyz/wagyourtail/unimined/util/IntegrationTestUtils.kt
+++ b/src/test/kotlin/xyz/wagyourtail/unimined/util/IntegrationTestUtils.kt
@@ -30,7 +30,7 @@ fun openZipFileSystem(project: String, path: String): FileSystem? {
 class IntegrationTestUtils {
     companion object {
         val GRADLE_VERSION = arrayOf(
-            "7.6.3",
+//            "7.6.3",
             "8.1.1",
             GRADLE_CURRENT,
             "8.5"


### PR DESCRIPTION
Now test compiling against java 8, 11, 17 and 21, and gradle 8.1, 8.4 and latest 8.
Run integration tests against java 17 and gradle 8.1.1, 8.4, 8.5.
Fixed running tests on Windows