### PR TITLE
Fixed empty JarJar metadata crashing forge

### DIFF
--- a/src/minecraft/kotlin/xyz/wagyourtail/unimined/internal/minecraft/patch/forge/fg3/FG3MinecraftTransformer.kt
+++ b/src/minecraft/kotlin/xyz/wagyourtail/unimined/internal/minecraft/patch/forge/fg3/FG3MinecraftTransformer.kt
@@ -558,7 +558,7 @@ class FG3MinecraftTransformer(project: Project, val parent: ForgeLikeMinecraftTr
             val mod = fs.getPath("META-INF/jarjar/metadata.json")
             val json = JsonObject()
 
-            val jarDir = fs.getPath("META-INF/jarjar/").createDirectories()
+            val jarDir = fs.getPath("META-INF/jarjar/")
             var hasJarJar = false
             for (dep in include!!.dependencies) {
                 val path = jarDir.resolve("${dep.name}-${dep.version}.jar")
@@ -572,6 +572,7 @@ class FG3MinecraftTransformer(project: Project, val parent: ForgeLikeMinecraftTr
             }
 
             if (hasJarJar) {
+                jarDir.createDirectories()
                 mod.writeBytes(FabricLikeMinecraftTransformer.GSON.toJson(json).toByteArray())
             }
         }

--- a/src/minecraft/kotlin/xyz/wagyourtail/unimined/internal/minecraft/patch/forge/fg3/FG3MinecraftTransformer.kt
+++ b/src/minecraft/kotlin/xyz/wagyourtail/unimined/internal/minecraft/patch/forge/fg3/FG3MinecraftTransformer.kt
@@ -559,6 +559,7 @@ class FG3MinecraftTransformer(project: Project, val parent: ForgeLikeMinecraftTr
             val json = JsonObject()
 
             val jarDir = fs.getPath("META-INF/jarjar/").createDirectories()
+            var hasJarJar = false
             for (dep in include!!.dependencies) {
                 val path = jarDir.resolve("${dep.name}-${dep.version}.jar")
                 if (!path.exists()) {
@@ -567,9 +568,12 @@ class FG3MinecraftTransformer(project: Project, val parent: ForgeLikeMinecraftTr
                 }
 
                 addIncludeToMetadata(json, dep, "META-INF/jarjar/${dep.name}-${dep.version}.jar")
+                hasJarJar = true
             }
 
-            mod.writeBytes(FabricLikeMinecraftTransformer.GSON.toJson(json).toByteArray())
+            if (hasJarJar) {
+                mod.writeBytes(FabricLikeMinecraftTransformer.GSON.toJson(json).toByteArray())
+            }
         }
     }
 


### PR DESCRIPTION
Currently if no jarjars are to be included, the metadata.json contains only an empty json object, causing lexforge and neoforge to crash:
```
Exception in thread "main" java.lang.NullPointerException: Cannot invoke "java.util.List.stream()" because the return value of "net.neoforged.jarjar.metadata.Metadata.jars()" is null
	at MC-BOOTSTRAP/JarJarSelector@0.4.0/net.neoforged.jarjar.selection.JarSelector.recursivelyDetectContainedJars(JarSelector.java:140)
	at MC-BOOTSTRAP/JarJarSelector@0.4.0/net.neoforged.jarjar.selection.JarSelector.detect(JarSelector.java:122)
	...
```
In Fabric the META-INF/jars folder is still created even if there are no jarjars present, this is not a problem, but should I fix that too?


Off-topic question: I also noticed that neoforge jars do not get remapped, but I also do not crash if I use an unremapped neoforge jar, do you know anything about that? Does neoforge remap at runtime now?
