### PR TITLE
ReIndev Support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,7 +29,7 @@ hs_err_pid*
 
 !src/main/resources/fmllibs/*
 
-testing/*/.gradle
-testing/*/build
-testing/*/.idea
-testing/*/run
+testing/**/.gradle
+testing/**/build
+testing/**/.idea
+testing/**/run

--- a/src/api/kotlin/xyz/wagyourtail/unimined/api/UniminedExtension.kt
+++ b/src/api/kotlin/xyz/wagyourtail/unimined/api/UniminedExtension.kt
@@ -61,7 +61,7 @@ abstract class UniminedExtension(val project: Project) {
     }
 
     @get:ApiStatus.Internal
-    abstract val minecrafts: DefaultMap<SourceSet, MinecraftConfig>
+    abstract val minecrafts: MutableMap<SourceSet, MinecraftConfig>
 
     @get:ApiStatus.Internal
     abstract val minecraftConfiguration: Map<SourceSet, MinecraftConfig.() -> Unit>
@@ -119,6 +119,62 @@ abstract class UniminedExtension(val project: Project) {
     ) {
         for (sourceSet in sourceSets) {
             minecraft(sourceSet, lateApply, action)
+        }
+    }
+
+    /**
+     * @since 1.4.0
+     */
+    @JvmOverloads
+    abstract fun reIndev(
+        sourceSet: SourceSet = sourceSets.getByName("main"),
+        lateApply: Boolean = false,
+        action: MinecraftConfig.() -> Unit
+    )
+
+    /**
+     * @since 1.4.0
+     */
+    @JvmOverloads
+    fun reIndev(
+        vararg sourceSets: SourceSet,
+        lateApply: Boolean = false,
+        action: MinecraftConfig.() -> Unit
+    ) {
+        for (sourceSet in sourceSets) {
+            reIndev(sourceSet, lateApply, action)
+        }
+    }
+
+    /**
+     * @since 1.4.0
+     */
+    @JvmOverloads
+    fun reIndev(
+        sourceSet: SourceSet = sourceSets.getByName("main"),
+        lateApply: Boolean = false,
+        @DelegatesTo(value = MinecraftConfig::class, strategy = Closure.DELEGATE_FIRST)
+        action: Closure<*>
+    ) {
+        reIndev(sourceSet, lateApply) {
+            action.delegate = this
+            action.resolveStrategy = Closure.DELEGATE_FIRST
+            action.call()
+        }
+    }
+
+    /**
+     * @since 1.4.0
+     */
+    @JvmOverloads
+    fun reIndev(
+        sourceSets: List<SourceSet>,
+        lateApply: Boolean = false,
+        @DelegatesTo(value = MinecraftConfig::class, strategy = Closure.DELEGATE_FIRST)
+        action: Closure<*>
+    ) {
+        for (sourceSet in sourceSets) {
+            reIndev(sourceSet, lateApply, action)
         }
     }
 

--- a/src/api/kotlin/xyz/wagyourtail/unimined/api/UniminedExtension.kt
+++ b/src/api/kotlin/xyz/wagyourtail/unimined/api/UniminedExtension.kt
@@ -214,4 +214,5 @@ abstract class UniminedExtension(val project: Project) {
 
     abstract fun cleanroomRepos()
     abstract fun outlandsMaven()
+    abstract fun fox2codeMaven()
 }

--- a/src/api/kotlin/xyz/wagyourtail/unimined/api/minecraft/MinecraftConfig.kt
+++ b/src/api/kotlin/xyz/wagyourtail/unimined/api/minecraft/MinecraftConfig.kt
@@ -103,6 +103,10 @@ abstract class MinecraftConfig(val project: Project, val sourceSet: SourceSet) :
     @set:ApiStatus.Internal
     abstract var mcPatcher: MinecraftPatcher
 
+    /**
+     * Whether the provided jars are generally obfuscated when downloaded
+     */
+    abstract val obfuscated: Boolean
     abstract val mappings: MappingsConfig
     abstract val mods: ModsConfig
     abstract val runs: RunsConfig

--- a/src/main/kotlin/xyz/wagyourtail/unimined/UniminedExtensionImpl.kt
+++ b/src/main/kotlin/xyz/wagyourtail/unimined/UniminedExtensionImpl.kt
@@ -272,6 +272,17 @@ open class UniminedExtensionImpl(project: Project) : UniminedExtension(project) 
         project.logger.info("[Unimined] adding outlands maven: $outlandsMaven")
     }
 
+    val fox2codeMaven by lazy {
+        project.repositories.maven {
+            it.name = "Fox2Code"
+            it.url = URI.create("https://cdn.fox2code.com/maven")
+        }
+    }
+
+    override fun fox2codeMaven() {
+        project.logger.info("[Unimined] adding Fox2Code maven: $fox2codeMaven")
+    }
+
     init {
         project.repositories.mavenCentral { repo ->
             repo.content {

--- a/src/main/kotlin/xyz/wagyourtail/unimined/UniminedExtensionImpl.kt
+++ b/src/main/kotlin/xyz/wagyourtail/unimined/UniminedExtensionImpl.kt
@@ -9,6 +9,7 @@ import xyz.wagyourtail.unimined.api.source.task.MigrateMappingsTask
 import xyz.wagyourtail.unimined.api.minecraft.MinecraftConfig
 import xyz.wagyourtail.unimined.internal.mapping.task.MigrateMappingsTaskImpl
 import xyz.wagyourtail.unimined.internal.minecraft.MinecraftProvider
+import xyz.wagyourtail.unimined.internal.minecraft.patch.reindev.ReIndevProvider
 import xyz.wagyourtail.unimined.util.defaultedMapOf
 import xyz.wagyourtail.unimined.util.withSourceSet
 import java.net.URI
@@ -16,15 +17,17 @@ import java.nio.file.Path
 
 open class UniminedExtensionImpl(project: Project) : UniminedExtension(project) {
 
-    override val minecrafts = defaultedMapOf<SourceSet, MinecraftConfig> {
-        MinecraftProvider(project, it)
-    }
+    override val minecrafts = mutableMapOf<SourceSet, MinecraftConfig>()
     override val minecraftConfiguration = mutableMapOf<SourceSet, MinecraftConfig.() -> Unit>()
     override fun minecraft(sourceSet: SourceSet, lateApply: Boolean, action: MinecraftConfig.() -> Unit) {
-        if (minecrafts.containsKey(sourceSet) && (minecrafts[sourceSet] as MinecraftProvider).applied) {
-            throw IllegalStateException("minecraft config for ${sourceSet.name} already applied, cannot configure further!")
-        } else if (!minecrafts.containsKey(sourceSet)) {
-            project.logger.info("[Unimined] registering minecraft config for ${sourceSet.name}")
+        if (minecrafts.containsKey(sourceSet)) {
+            if ((minecrafts[sourceSet] as MinecraftProvider).applied) {
+                throw IllegalStateException("minecraft config for ${sourceSet.name} already applied, cannot configure further!")
+            } else {
+                project.logger.info("[Unimined] registering minecraft config for ${sourceSet.name}")
+            }
+        } else {
+            minecrafts[sourceSet] = MinecraftProvider(project, sourceSet)
         }
         minecraftConfiguration.compute(sourceSet) { _, old ->
             if (old != null) {
@@ -36,8 +39,31 @@ open class UniminedExtensionImpl(project: Project) : UniminedExtension(project) 
                 action
             }
         }
-        minecrafts[sourceSet].action()
+        minecrafts[sourceSet]?.action()
         if (!lateApply) (minecrafts[sourceSet] as MinecraftProvider).apply()
+    }
+    override fun reIndev(sourceSet: SourceSet, lateApply: Boolean, action: MinecraftConfig.() -> Unit) {
+        if (minecrafts.containsKey(sourceSet)) {
+            if ((minecrafts[sourceSet] as ReIndevProvider).applied) {
+                throw IllegalStateException("minecraft config for ${sourceSet.name} already applied, cannot configure further!")
+            } else {
+                project.logger.info("[Unimined] registering reIndev config for ${sourceSet.name}")
+            }
+        } else {
+            minecrafts[sourceSet] = ReIndevProvider(project, sourceSet)
+        }
+        minecraftConfiguration.compute(sourceSet) { _, old ->
+            if (old != null) {
+                {
+                    old()
+                    action()
+                }
+            } else {
+                action
+            }
+        }
+        minecrafts[sourceSet]?.action()
+        if (!lateApply) (minecrafts[sourceSet] as ReIndevProvider).apply()
     }
 
     override fun migrateMappings(sourceSet: SourceSet, action: MigrateMappingsTask.() -> Unit) {

--- a/src/mapping/kotlin/xyz/wagyourtail/unimined/internal/mapping/task/MigrateMappingsTaskImpl.kt
+++ b/src/mapping/kotlin/xyz/wagyourtail/unimined/internal/mapping/task/MigrateMappingsTaskImpl.kt
@@ -3,17 +3,11 @@ package xyz.wagyourtail.unimined.internal.mapping.task
 import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.SourceSet
 import org.gradle.api.tasks.TaskAction
-import xyz.wagyourtail.unimined.api.mapping.MappingNamespaceTree
 import xyz.wagyourtail.unimined.api.minecraft.MinecraftConfig
-import xyz.wagyourtail.unimined.api.mapping.task.ExportMappingsTask
 import xyz.wagyourtail.unimined.api.source.task.MigrateMappingsTask
 import xyz.wagyourtail.unimined.api.unimined
-import xyz.wagyourtail.unimined.internal.mapping.MappingsProvider
-import xyz.wagyourtail.unimined.util.deleteRecursively
 import xyz.wagyourtail.unimined.util.sourceSets
 import xyz.wagyourtail.unimined.util.withSourceSet
-import java.io.File
-import java.nio.file.Path
 import java.nio.file.StandardCopyOption
 import javax.inject.Inject
 import kotlin.io.path.*
@@ -35,7 +29,7 @@ abstract class MigrateMappingsTaskImpl @Inject constructor(@get:Internal val sou
     @TaskAction
     fun run() {
         val commonNs = commonNamespace.get()
-        val inputMinecraft = project.unimined.minecrafts.map[sourceSet]!!
+        val inputMinecraft = project.unimined.minecrafts[sourceSet]!!
 
         //step 1, remap input to common namespace
         val inputDevNs = inputMinecraft.mappings.devNamespace
@@ -55,7 +49,7 @@ abstract class MigrateMappingsTaskImpl @Inject constructor(@get:Internal val sou
         )
 
         // step2, remap common to target
-        val outputMinecraft = project.unimined.minecrafts.map[migrateSourceSet]!!
+        val outputMinecraft = project.unimined.minecrafts[migrateSourceSet]!!
 
         val outputCommonNs = outputMinecraft.mappings.getNamespace(commonNs)
         val outputDevNs = outputMinecraft.mappings.devNamespace

--- a/src/minecraft/kotlin/xyz/wagyourtail/unimined/internal/minecraft/MinecraftProvider.kt
+++ b/src/minecraft/kotlin/xyz/wagyourtail/unimined/internal/minecraft/MinecraftProvider.kt
@@ -72,6 +72,8 @@ import kotlin.io.path.*
 open class MinecraftProvider(project: Project, sourceSet: SourceSet) : MinecraftConfig(project, sourceSet) {
     override val minecraftData = MinecraftDownloader(project, this)
 
+    override val obfuscated = true
+
     override val mappings = MappingsProvider(project, this)
 
     override var mcPatcher: MinecraftPatcher by FinalizeOnRead(FinalizeOnWrite(NoTransformMinecraftTransformer(project, this)))

--- a/src/minecraft/kotlin/xyz/wagyourtail/unimined/internal/minecraft/MinecraftProvider.kt
+++ b/src/minecraft/kotlin/xyz/wagyourtail/unimined/internal/minecraft/MinecraftProvider.kt
@@ -45,6 +45,7 @@ import xyz.wagyourtail.unimined.internal.minecraft.patch.forge.MinecraftForgeMin
 import xyz.wagyourtail.unimined.internal.minecraft.patch.forge.NeoForgedMinecraftTransformer
 import xyz.wagyourtail.unimined.internal.minecraft.patch.jarmod.JarModAgentMinecraftTransformer
 import xyz.wagyourtail.unimined.internal.minecraft.patch.merged.MergedMinecraftTransformer
+import xyz.wagyourtail.unimined.internal.minecraft.patch.reindev.NoTransformReIndevTransformer
 import xyz.wagyourtail.unimined.internal.minecraft.patch.rift.RiftMinecraftTransformer
 import xyz.wagyourtail.unimined.internal.minecraft.resolver.AssetsDownloader
 import xyz.wagyourtail.unimined.internal.minecraft.resolver.Extract
@@ -68,7 +69,7 @@ import java.util.*
 import kotlin.collections.ArrayDeque
 import kotlin.io.path.*
 
-class MinecraftProvider(project: Project, sourceSet: SourceSet) : MinecraftConfig(project, sourceSet) {
+open class MinecraftProvider(project: Project, sourceSet: SourceSet) : MinecraftConfig(project, sourceSet) {
     override val minecraftData = MinecraftDownloader(project, this)
 
     override val mappings = MappingsProvider(project, this)
@@ -154,7 +155,7 @@ class MinecraftProvider(project: Project, sourceSet: SourceSet) : MinecraftConfi
         }
     }
 
-    private val minecraftFiles: Map<Pair<MappingNamespaceTree.Namespace, MappingNamespaceTree.Namespace>, MinecraftJar> = defaultedMapOf {
+    protected open val minecraftFiles: Map<Pair<MappingNamespaceTree.Namespace, MappingNamespaceTree.Namespace>, MinecraftJar> = defaultedMapOf {
         project.logger.info("[Unimined/Minecraft ${project.path}:${sourceSet.name}] Providing minecraft files for $it")
         val mc = if (side == EnvType.COMBINED) {
             val client = minecraftData.minecraftClient
@@ -380,7 +381,7 @@ class MinecraftProvider(project: Project, sourceSet: SourceSet) : MinecraftConfi
         } as ModuleDependency
     }
 
-    private val extractDependencies: MutableMap<Dependency, Extract> = mutableMapOf()
+    protected val extractDependencies: MutableMap<Dependency, Extract> = mutableMapOf()
 
     fun addLibraries(libraries: List<Library>) {
         for (library in libraries) {
@@ -624,7 +625,7 @@ class MinecraftProvider(project: Project, sourceSet: SourceSet) : MinecraftConfi
 
 
     @ApiStatus.Internal
-    fun provideRunClientTask(name: String, defaultWorkingDir: File) {
+    open fun provideRunClientTask(name: String, defaultWorkingDir: File) {
         project.logger.info("[Unimined/Minecraft ${project.path}:${sourceSet.name}] client config, $name")
 
         runs.preLaunch(name) {

--- a/src/minecraft/kotlin/xyz/wagyourtail/unimined/internal/minecraft/patch/AbstractMinecraftTransformer.kt
+++ b/src/minecraft/kotlin/xyz/wagyourtail/unimined/internal/minecraft/patch/AbstractMinecraftTransformer.kt
@@ -274,7 +274,7 @@ abstract class AbstractMinecraftTransformer protected constructor(
     protected fun sortProjectSourceSets(): Map<Pair<Project, SourceSet>, Set<Pair<Project, SourceSet>>> {
         val minecraftConfigs = mutableMapOf<Pair<Project, SourceSet>, MinecraftConfig?>()
         for ((project, sourceSet) in detectProjectSourceSets()) {
-            minecraftConfigs[project to sourceSet] = project.uniminedMaybe?.minecrafts?.map?.get(sourceSet)
+            minecraftConfigs[project to sourceSet] = project.uniminedMaybe?.minecrafts?.get(sourceSet)
         }
         // ensure all minecraft ones on same mappings
         // get current mappings

--- a/src/minecraft/kotlin/xyz/wagyourtail/unimined/internal/minecraft/patch/bukkit/CraftbukkitMinecraftTransformer.kt
+++ b/src/minecraft/kotlin/xyz/wagyourtail/unimined/internal/minecraft/patch/bukkit/CraftbukkitMinecraftTransformer.kt
@@ -181,7 +181,7 @@ open class CraftbukkitMinecraftTransformer(
         val groups = sortProjectSourceSets().mapValues { it.value.toMutableSet() }.toMutableMap()
         // detect non-fabric groups
         for ((proj, sourceSet) in groups.keys.toSet()) {
-            if (proj.uniminedMaybe?.minecrafts?.map?.get(sourceSet)?.mcPatcher !is CraftbukkitPatcher) {
+            if (proj.uniminedMaybe?.minecrafts?.get(sourceSet)?.mcPatcher !is CraftbukkitPatcher) {
                 // merge with current
                 proj.logger.warn("[Unimined/FabricLike] Non-fabric ${(proj to sourceSet).toPath()} found in fabric classpath groups, merging with current (${(project to provider.sourceSet).toPath()}), this should've been manually specified with `combineWith`")
                 groups[this.project to this.provider.sourceSet]!! += groups[proj to sourceSet]!!

--- a/src/minecraft/kotlin/xyz/wagyourtail/unimined/internal/minecraft/patch/fabric/FabricLikeMinecraftTransformer.kt
+++ b/src/minecraft/kotlin/xyz/wagyourtail/unimined/internal/minecraft/patch/fabric/FabricLikeMinecraftTransformer.kt
@@ -65,7 +65,7 @@ abstract class FabricLikeMinecraftTransformer(
 
     private val include: Configuration = project.configurations.maybeCreate("include".withSourceSet(provider.sourceSet))
 
-    override var customIntermediaries: Boolean by FinalizeOnRead(provider is ReIndevProvider)
+    override var customIntermediaries: Boolean by FinalizeOnRead(!provider.obfuscated)
 
     override var skipInsertAw: Boolean by FinalizeOnRead(false)
 
@@ -97,14 +97,14 @@ abstract class FabricLikeMinecraftTransformer(
     )
 
     override var prodNamespace by FinalizeOnRead(LazyMutable {
-        if (provider is ReIndevProvider) return@LazyMutable provider.mappings.OFFICIAL
+        if (!provider.obfuscated) return@LazyMutable provider.mappings.OFFICIAL
         provider.mappings.getNamespace("intermediary")
     })
 
     @get:ApiStatus.Internal
     @set:ApiStatus.Experimental
     override var devMappings: Path? by FinalizeOnRead(LazyMutable {
-        if (provider is ReIndevProvider) return@LazyMutable null
+        if (!provider.obfuscated) return@LazyMutable null
         provider.localCache
             .resolve("mappings")
             .createDirectories()

--- a/src/minecraft/kotlin/xyz/wagyourtail/unimined/internal/minecraft/patch/fabric/FabricMinecraftTransformer.kt
+++ b/src/minecraft/kotlin/xyz/wagyourtail/unimined/internal/minecraft/patch/fabric/FabricMinecraftTransformer.kt
@@ -10,6 +10,7 @@ import xyz.wagyourtail.unimined.api.runs.RunConfig
 import xyz.wagyourtail.unimined.api.unimined
 import xyz.wagyourtail.unimined.internal.minecraft.MinecraftProvider
 import xyz.wagyourtail.unimined.api.minecraft.MinecraftJar
+import xyz.wagyourtail.unimined.internal.minecraft.patch.reindev.ReIndevProvider
 import xyz.wagyourtail.unimined.util.SemVerUtils
 import java.io.InputStreamReader
 import java.nio.file.Files
@@ -104,6 +105,9 @@ abstract class FabricMinecraftTransformer(
             "-Dfabric.remapClasspathFile=${intermediaryClasspath}",
             "-Dfabric.classPathGroups=${groups}"
         )
+        if (provider is ReIndevProvider) {
+            config.jvmArgs("-Dfabric.gameVersion=b1.7.3")
+        }
     }
 
     override fun applyServerRunTransform(config: RunConfig) {
@@ -113,6 +117,9 @@ abstract class FabricMinecraftTransformer(
             "-Dfabric.remapClasspathFile=${intermediaryClasspath}",
             "-Dfabric.classPathGroups=${groups}"
         )
+        if (provider is ReIndevProvider) {
+            config.jvmArgs("-Dfabric.gameVersion=b1.7.3")
+        }
     }
 
     override fun collectInterfaceInjections(baseMinecraft: MinecraftJar, injections: HashMap<String, List<String>>) {

--- a/src/minecraft/kotlin/xyz/wagyourtail/unimined/internal/minecraft/patch/forge/ForgeLikeMinecraftTransformer.kt
+++ b/src/minecraft/kotlin/xyz/wagyourtail/unimined/internal/minecraft/patch/forge/ForgeLikeMinecraftTransformer.kt
@@ -334,7 +334,7 @@ abstract class ForgeLikeMinecraftTransformer(
         val groups = sortProjectSourceSets().mapValues { it.value.toMutableSet() }.toMutableMap()
         // detect non-forge groups
         for ((proj, sourceSet) in groups.keys.toSet()) {
-            if (proj.uniminedMaybe?.minecrafts?.map?.get(sourceSet)?.mcPatcher !is ForgeLikePatcher<*>) {
+            if (proj.uniminedMaybe?.minecrafts?.get(sourceSet)?.mcPatcher !is ForgeLikePatcher<*>) {
                 // merge with current
                 proj.logger.warn("[Unimined/ForgeLike] Non-forge ${(proj to sourceSet).toPath()} found in forge classpath groups, merging with current (${(project to provider.sourceSet).toPath()}), this should've been manually specified with `combineWith`")
                 groups[this.project to this.provider.sourceSet]!! += groups[proj to sourceSet]!!

--- a/src/minecraft/kotlin/xyz/wagyourtail/unimined/internal/minecraft/patch/reindev/AbstractReIndevTransformer.kt
+++ b/src/minecraft/kotlin/xyz/wagyourtail/unimined/internal/minecraft/patch/reindev/AbstractReIndevTransformer.kt
@@ -1,0 +1,25 @@
+package xyz.wagyourtail.unimined.internal.minecraft.patch.reindev
+
+import org.gradle.api.Project
+import xyz.wagyourtail.unimined.api.unimined
+import xyz.wagyourtail.unimined.internal.minecraft.MinecraftProvider
+import xyz.wagyourtail.unimined.internal.minecraft.patch.AbstractMinecraftTransformer
+import xyz.wagyourtail.unimined.internal.minecraft.resolver.Library
+import xyz.wagyourtail.unimined.util.SemVerUtils
+
+abstract class AbstractReIndevTransformer(
+    project: Project,
+    provider: MinecraftProvider,
+    providerName: String
+) : AbstractMinecraftTransformer(project, provider, providerName) {
+
+    override var canCombine: Boolean = SemVerUtils.matches(provider.version.replace("_", "."), ">2.9")
+
+    init {
+        addMavens()
+    }
+
+    fun addMavens() {
+        project.unimined.fox2codeMaven()
+    }
+}

--- a/src/minecraft/kotlin/xyz/wagyourtail/unimined/internal/minecraft/patch/reindev/NoTransformReIndevTransformer.kt
+++ b/src/minecraft/kotlin/xyz/wagyourtail/unimined/internal/minecraft/patch/reindev/NoTransformReIndevTransformer.kt
@@ -1,0 +1,25 @@
+package xyz.wagyourtail.unimined.internal.minecraft.patch.reindev
+
+import org.gradle.api.Project
+import xyz.wagyourtail.unimined.api.mapping.MappingNamespaceTree
+import xyz.wagyourtail.unimined.api.minecraft.EnvType
+import xyz.wagyourtail.unimined.api.minecraft.MinecraftJar
+import xyz.wagyourtail.unimined.api.unimined
+import xyz.wagyourtail.unimined.internal.minecraft.MinecraftProvider
+import xyz.wagyourtail.unimined.internal.minecraft.patch.AbstractMinecraftTransformer
+import xyz.wagyourtail.unimined.util.*
+import java.net.URI
+import java.nio.file.Path
+import kotlin.io.path.createDirectories
+import kotlin.io.path.exists
+import kotlin.time.Duration
+
+class NoTransformReIndevTransformer(project: Project, provider: ReIndevProvider): AbstractReIndevTransformer(
+    project,
+    provider,
+    "ReIndev-none"
+) {
+
+    override var prodNamespace: MappingNamespaceTree.Namespace = provider.mappings.OFFICIAL
+
+}

--- a/src/minecraft/kotlin/xyz/wagyourtail/unimined/internal/minecraft/patch/reindev/ReIndevDownloader.kt
+++ b/src/minecraft/kotlin/xyz/wagyourtail/unimined/internal/minecraft/patch/reindev/ReIndevDownloader.kt
@@ -1,0 +1,85 @@
+package xyz.wagyourtail.unimined.internal.minecraft.patch.reindev
+
+import org.gradle.api.Project
+import xyz.wagyourtail.unimined.api.minecraft.EnvType
+import xyz.wagyourtail.unimined.api.minecraft.MinecraftJar
+import xyz.wagyourtail.unimined.api.unimined
+import xyz.wagyourtail.unimined.internal.minecraft.MinecraftProvider
+import xyz.wagyourtail.unimined.internal.minecraft.resolver.MinecraftDownloader
+import xyz.wagyourtail.unimined.util.FinalizeOnRead
+import xyz.wagyourtail.unimined.util.LazyMutable
+import xyz.wagyourtail.unimined.util.cachingDownload
+import java.net.URI
+import java.nio.file.Path
+import kotlin.io.path.createDirectories
+import kotlin.io.path.exists
+import kotlin.time.Duration
+
+class ReIndevDownloader(project: Project, provider: MinecraftProvider) : MinecraftDownloader(project, provider) {
+
+    val fileBaseURL: URI = URI.create("https://cdn.fox2code.com/files/")
+
+    override val mcVersionFolder: Path by lazy {
+        project.unimined.getGlobalCache()
+            .resolve("net")
+            .resolve("silveros")
+            .resolve("reindev")
+            .resolve(version)
+    }
+
+    override var metadataURL: URI by FinalizeOnRead(LazyMutable {
+        val versionIndex = getVersionFromLauncherMeta("b1.7.3")
+        val url = versionIndex.get("url").asString
+        URI.create(url)
+    })
+
+    override val minecraftClient: MinecraftJar by lazy {
+        project.logger.info("[Unimined/MinecraftDownloader] retrieving ReIndev client jar")
+        val clientPath = mcVersionFolder.resolve("reindev-$version-client.jar")
+        if (!clientPath.exists() || project.unimined.forceReload) {
+            mcVersionFolder.createDirectories()
+            project.cachingDownload(
+                fileBaseURL.resolve("reindev_${version}.jar"),
+                cachePath = clientPath,
+                expireTime = Duration.INFINITE
+            )
+        }
+        MinecraftJar(
+            mcVersionFolder,
+            "reindev",
+            EnvType.CLIENT,
+            version,
+            listOf(),
+            provider.mappings.OFFICIAL,
+            provider.mappings.OFFICIAL,
+            null,
+            "jar",
+            clientPath
+        )
+    }
+
+    override val minecraftServer: MinecraftJar by lazy {
+        project.logger.info("[Unimined/MinecraftDownloader] retrieving ReIndev server jar")
+        val serverPath = mcVersionFolder.resolve("reindev-${version}-server.jar")
+        if (!serverPath.exists() || project.unimined.forceReload) {
+            mcVersionFolder.createDirectories()
+            project.cachingDownload(
+                fileBaseURL.resolve("reindev_${version}_server.jar"),
+                cachePath = serverPath,
+                expireTime = Duration.INFINITE
+            )
+        }
+        MinecraftJar(
+            mcVersionFolder,
+            "reindev",
+            EnvType.SERVER,
+            version,
+            listOf(),
+            provider.mappings.OFFICIAL,
+            provider.mappings.OFFICIAL,
+            null,
+            "jar",
+            serverPath
+        )
+    }
+}

--- a/src/minecraft/kotlin/xyz/wagyourtail/unimined/internal/minecraft/patch/reindev/ReIndevProvider.kt
+++ b/src/minecraft/kotlin/xyz/wagyourtail/unimined/internal/minecraft/patch/reindev/ReIndevProvider.kt
@@ -11,7 +11,9 @@ import kotlin.io.path.exists
 
 class ReIndevProvider(project: Project, sourceSet: SourceSet) : MinecraftProvider(project, sourceSet) {
 
-    override val minecraftData: MinecraftDownloader = ReIndevDownloader(project, this)
+    override val obfuscated = false
+
+    override val minecraftData = ReIndevDownloader(project, this)
 
     init {
         // Required for the following [2.9.4+legacyfabric.8,) dependency

--- a/src/minecraft/kotlin/xyz/wagyourtail/unimined/internal/minecraft/patch/reindev/ReIndevProvider.kt
+++ b/src/minecraft/kotlin/xyz/wagyourtail/unimined/internal/minecraft/patch/reindev/ReIndevProvider.kt
@@ -1,0 +1,52 @@
+package xyz.wagyourtail.unimined.internal.minecraft.patch.reindev
+
+import org.gradle.api.Project
+import org.gradle.api.tasks.SourceSet
+import xyz.wagyourtail.unimined.api.unimined
+import xyz.wagyourtail.unimined.internal.minecraft.MinecraftProvider
+import xyz.wagyourtail.unimined.internal.minecraft.resolver.MinecraftDownloader
+import java.io.File
+import java.io.IOException
+import kotlin.io.path.exists
+
+class ReIndevProvider(project: Project, sourceSet: SourceSet) : MinecraftProvider(project, sourceSet) {
+
+    override val minecraftData: MinecraftDownloader = ReIndevDownloader(project, this)
+
+    init {
+        // Required for the following [2.9.4+legacyfabric.8,) dependency
+        project.unimined.legacyFabricMaven()
+        project.configurations.configureEach {
+            it.resolutionStrategy.eachDependency {
+                val group = it.requested.group
+                val name = it.requested.name
+                val module = "$group:$name"
+                if (module == "org.ow2.asm:asm-all") {
+                    // Upgrades the class compatibility level to Java 8 to match ReIndev
+                    it.useVersion("5.2")
+                } else if (group.startsWith("org.lwjgl")) {
+                    // Fixes several bugs, including failure to launch on Linux
+                    it.useVersion("[2.9.4+legacyfabric.8,)")
+                } else if (module == "net.java.jinput:jinput") {
+                    // Upgrading the JInput version to the latest fixes minor bugs like incompatible version notices
+                    it.useVersion("[${it.requested.version},2.0.9]")
+                }
+            }
+        }
+
+        mappings.devNamespace = mappings.OFFICIAL
+        mappings.devFallbackNamespace = mappings.OFFICIAL
+    }
+
+    override val mergedOfficialMinecraftFile: File? by lazy {
+        val client = minecraftData.minecraftClient
+        if (!client.path.exists()) throw IOException("ReIndev path $client does not exist")
+        val server = minecraftData.minecraftServer
+        val noTransform = NoTransformReIndevTransformer(project, this)
+        if (noTransform.canCombine) {
+            noTransform.merge(client, server).path.toFile()
+        } else {
+            null
+        }
+    }
+}

--- a/src/minecraft/kotlin/xyz/wagyourtail/unimined/internal/minecraft/resolver/MinecraftDownloader.kt
+++ b/src/minecraft/kotlin/xyz/wagyourtail/unimined/internal/minecraft/resolver/MinecraftDownloader.kt
@@ -23,12 +23,12 @@ import java.util.zip.ZipOutputStream
 import kotlin.io.path.*
 import kotlin.time.Duration.Companion.seconds
 
-class MinecraftDownloader(val project: Project, val provider: MinecraftProvider) : MinecraftData() {
+open class MinecraftDownloader(val project: Project, val provider: MinecraftProvider) : MinecraftData() {
 
     val version
         get() = provider.version
 
-    val mcVersionFolder: Path by lazy {
+    open val mcVersionFolder: Path by lazy {
         project.unimined.getGlobalCache()
             .resolve("net")
             .resolve("minecraft")
@@ -79,7 +79,7 @@ class MinecraftDownloader(val project: Project, val provider: MinecraftProvider)
         versionsList.getAsJsonArray("versions") ?: throw Exception("Failed to get metadata, no versions")
     }
 
-    private fun getVersionFromLauncherMeta(versionId: String): JsonObject {
+    protected fun getVersionFromLauncherMeta(versionId: String): JsonObject {
         for (version in launcherMeta) {
             val versionObject = version.asJsonObject
             val id = versionObject.get("id").asString
@@ -131,7 +131,7 @@ class MinecraftDownloader(val project: Project, val provider: MinecraftProvider)
         )
     }
 
-    val minecraftClient: MinecraftJar by lazy {
+    open val minecraftClient: MinecraftJar by lazy {
         project.logger.info("[Unimined/MinecraftDownloader] retrieving minecraft client jar")
         val clientPath = mcVersionFolder.resolve("minecraft-$version-client.jar")
         if (!clientPath.exists() || project.unimined.forceReload) {
@@ -186,7 +186,7 @@ class MinecraftDownloader(val project: Project, val provider: MinecraftProvider)
         versionOverrides.getOrDefault(version, version)
     })
 
-    val minecraftServer: MinecraftJar by lazy {
+    open val minecraftServer: MinecraftJar by lazy {
         project.logger.info("[Unimined/MinecraftDownloader] retrieving minecraft server jar")
         var serverPath = mcVersionFolder.resolve("minecraft-$version-server.jar")
         if (!serverPath.exists() || project.unimined.forceReload) {

--- a/testing/reindev/2.8.1_06-Fabric/build.gradle
+++ b/testing/reindev/2.8.1_06-Fabric/build.gradle
@@ -1,0 +1,72 @@
+plugins {
+    id 'java'
+    id 'xyz.wagyourtail.unimined' // version '[1.4.0,)'
+}
+
+group = 'com.example'
+base.archivesName = 'UniminedExampleMod'
+version = '1.0.0'
+
+sourceSets {
+    client {
+        compileClasspath += sourceSets.main.output
+        runtimeClasspath += sourceSets.main.output
+    }
+    server {
+        compileClasspath += sourceSets.main.output
+        runtimeClasspath += sourceSets.main.output
+    }
+}
+
+unimined {
+    // this is just here so we can test the outputs easier and clean between tests
+    useGlobalCache = false
+
+    reIndev {
+        version '2.8.1_06'
+        side 'client'
+
+        defaultRemapJar = false
+
+        fabric {
+            loader '0.16.0'
+        }
+
+        runs.config('client') {
+            javaVersion = JavaVersion.VERSION_1_8
+            enabled = false
+        }
+        runs.config('server') {
+            javaVersion = JavaVersion.VERSION_1_8
+            enabled = false
+        }
+    }
+
+    reIndev(sourceSets.client) {
+        combineWith(sourceSets.main)
+
+        runs.config('client') {
+            javaVersion = JavaVersion.VERSION_1_8
+            enabled = true
+        }
+    }
+
+    reIndev(sourceSets.server) {
+        combineWith(sourceSets.main)
+        side 'server'
+
+        runs.config('server') {
+            javaVersion = JavaVersion.VERSION_1_8
+            enabled = true
+        }
+    }
+}
+
+repositories {
+    unimined.legacyFabricMaven()
+}
+
+java {
+    sourceCompatibility = targetCompatibility = JavaVersion.VERSION_1_8
+    toolchain.languageVersion = JavaLanguageVersion.of(8)
+}

--- a/testing/reindev/2.8.1_06-Fabric/settings.gradle
+++ b/testing/reindev/2.8.1_06-Fabric/settings.gradle
@@ -1,0 +1,23 @@
+pluginManagement {
+    repositories {
+        mavenCentral()
+        gradlePluginPortal() {
+            content {
+                excludeGroup('org.apache.logging.log4j')
+            }
+        }
+        maven {
+            name = 'WagYourTail Releases'
+            url = 'https://maven.wagyourtail.xyz/releases'
+        }
+        maven {
+            name = 'WagYourTail Snapshots'
+            url = 'https://maven.wagyourtail.xyz/snapshots'
+        }
+    }
+}
+
+// so we can use the unimined directly provided by the super project
+includeBuild('../../../')
+
+rootProject.name = 'ReIndev-2.8.1_06-Fabric'

--- a/testing/reindev/2.8.1_06-Fabric/src/client/java/com/example/fabric/client/ClientExampleMod.java
+++ b/testing/reindev/2.8.1_06-Fabric/src/client/java/com/example/fabric/client/ClientExampleMod.java
@@ -1,0 +1,11 @@
+package com.example.fabric.client;
+
+import net.fabricmc.api.*;
+import xyz.wagyourtail.unimined.example.mod.*;
+
+public class ClientExampleMod implements ClientModInitializer {
+	@Override
+	public void onInitializeClient() {
+		ExampleMod.LOGGER.info("Hello Fabric client world!");
+	}
+}

--- a/testing/reindev/2.8.1_06-Fabric/src/client/resources/fabric.mod.json
+++ b/testing/reindev/2.8.1_06-Fabric/src/client/resources/fabric.mod.json
@@ -1,0 +1,30 @@
+{
+  "schemaVersion": 1,
+  "id": "modid",
+  "version": "${version}",
+
+  "name": "Example Mod",
+  "description": "This is an example description! Tell everyone what your mod is about!",
+  "authors": [
+    "Me!"
+  ],
+  "contact": {
+    "homepage": "https://fabricmc.net/",
+    "sources": "https://github.com/FabricMC/fabric-example-mod"
+  },
+
+  "license": "CC0-1.0",
+
+  "environment": "client",
+  "entrypoints": {
+    "client": [
+      "com.example.fabric.client.ClientExampleMod"
+    ]
+  },
+  "mixins": [
+  ],
+
+  "depends": {
+    "java": ">=8"
+  }
+}

--- a/testing/reindev/2.8.1_06-Fabric/src/main/java/xyz/wagyourtail/unimined/example/mod/ExampleMod.java
+++ b/testing/reindev/2.8.1_06-Fabric/src/main/java/xyz/wagyourtail/unimined/example/mod/ExampleMod.java
@@ -1,0 +1,7 @@
+package xyz.wagyourtail.unimined.example.mod;
+
+import java.util.logging.*;
+
+public class ExampleMod {
+	public static final Logger LOGGER = Logger.getLogger(ExampleMod.class.getSimpleName());
+}

--- a/testing/reindev/2.8.1_06-Fabric/src/server/java/com/example/fabric/server/ServerExampleMod.java
+++ b/testing/reindev/2.8.1_06-Fabric/src/server/java/com/example/fabric/server/ServerExampleMod.java
@@ -1,0 +1,11 @@
+package com.example.fabric.server;
+
+import net.fabricmc.api.*;
+import xyz.wagyourtail.unimined.example.mod.*;
+
+public class ServerExampleMod implements DedicatedServerModInitializer {
+	@Override
+	public void onInitializeServer() {
+		ExampleMod.LOGGER.info("Hello Fabric server world!");
+	}
+}

--- a/testing/reindev/2.8.1_06-Fabric/src/server/resources/fabric.mod.json
+++ b/testing/reindev/2.8.1_06-Fabric/src/server/resources/fabric.mod.json
@@ -1,0 +1,30 @@
+{
+  "schemaVersion": 1,
+  "id": "modid",
+  "version": "${version}",
+
+  "name": "Example Mod",
+  "description": "This is an example description! Tell everyone what your mod is about!",
+  "authors": [
+    "Me!"
+  ],
+  "contact": {
+    "homepage": "https://fabricmc.net/",
+    "sources": "https://github.com/FabricMC/fabric-example-mod"
+  },
+
+  "license": "CC0-1.0",
+
+  "environment": "server",
+  "entrypoints": {
+    "server": [
+      "com.example.fabric.server.ServerExampleMod"
+    ]
+  },
+  "mixins": [
+  ],
+
+  "depends": {
+    "java": ">=8"
+  }
+}


### PR DESCRIPTION
- Added Fox2Code maven for retrieving FoxLoader
- Added `ReIndevProvider` to enable getting the Minecraft: ReIndev jar as a Minecraft jar.

# To-do

- [x] ~~Add `NoTransformReIndevTransformer` for ReIndev jar modding~~
	Replaced with `ReIndevProvider`
- [ ] Add `FoxLoaderReIndevTransformer` for FoxLoader modding
	Will do in a later PR