### PR TITLE
Modrinth/CurseForge Mavens

### DIFF
--- a/src/api/kotlin/xyz/wagyourtail/unimined/api/UniminedExtension.kt
+++ b/src/api/kotlin/xyz/wagyourtail/unimined/api/UniminedExtension.kt
@@ -271,4 +271,6 @@ abstract class UniminedExtension(val project: Project) {
     abstract fun cleanroomRepos()
     abstract fun outlandsMaven()
     abstract fun fox2codeMaven()
+    abstract fun modrinthMaven()
+    abstract fun curseMaven(beta: Boolean = false)
 }

--- a/src/main/kotlin/xyz/wagyourtail/unimined/UniminedExtensionImpl.kt
+++ b/src/main/kotlin/xyz/wagyourtail/unimined/UniminedExtensionImpl.kt
@@ -309,6 +309,103 @@ open class UniminedExtensionImpl(project: Project) : UniminedExtension(project) 
         project.logger.info("[Unimined] adding Fox2Code maven: $fox2codeMaven")
     }
 
+    val modrinthMaven by lazy {
+        project.repositories.exclusiveContent {
+            it.forRepository {
+                project.repositories.maven {
+                    it.name = "modrinth"
+                    it.url = URI.create("https://api.modrinth.com/maven")
+                }
+            }
+
+            it.filter {
+                it.includeGroup("maven.modrinth")
+            }
+        }
+    }
+
+    val backupModrinthMaven by lazy {
+        project.repositories.maven {
+            it.name = "modrinth"
+            it.url = URI.create("https://api.modrinth.com/maven")
+            it.content {
+                it.includeGroup("maven.modrinth")
+            }
+        }
+    }
+
+    override fun modrinthMaven() {
+        try {
+            project.logger.info("[Unimined] adding Modrinth maven: $modrinthMaven")
+        } catch (e: Throwable) {
+            project.logger.warn("[Unimined] failed to add Modrinth maven, falling back to backup")
+            project.logger.warn(e.stackTraceToString())
+            project.logger.info("[Unimined] adding Modrinth maven: $backupModrinthMaven")
+        }
+    }
+
+    val curseMaven by lazy {
+        project.repositories.exclusiveContent {
+            it.forRepository {
+                project.repositories.maven {
+                    it.name = "cursemaven"
+                    it.url = URI.create("https://cursemaven.com")
+                }
+            }
+
+            it.filter {
+                it.includeGroup("curse.maven")
+            }
+        }
+    }
+
+    val backupCurseMaven by lazy {
+        project.repositories.maven {
+            it.name = "cursemaven"
+            it.url = URI.create("https://cursemaven.com")
+
+            it.content {
+                it.includeGroup("curse.maven")
+            }
+        }
+    }
+
+    val betaCurseMaven by lazy {
+        project.repositories.exclusiveContent {
+            it.forRepository {
+                project.repositories.maven {
+                    it.name = "beta-cursemaven"
+                    it.url = URI.create("https://beta.cursemaven.com")
+                }
+            }
+
+            it.filter {
+                it.includeGroup("curse.maven")
+            }
+        }
+    }
+
+    val backupBetaCurseMaven by lazy {
+        project.repositories.maven {
+            it.name = "beta-cursemaven"
+            it.url = URI.create("https://beta.cursemaven.com")
+
+            it.content {
+                it.includeGroup("curse.maven")
+            }
+        }
+    }
+
+    override fun curseMaven(beta: Boolean /* = false */) {
+        try {
+            project.logger.info("[Unimined] adding Curse maven: ${if (beta) betaCurseMaven else curseMaven}")
+        } catch (e: Throwable) {
+            project.logger.warn("[Unimined] failed to add Curse maven, falling back to backup")
+            project.logger.warn(e.stackTraceToString())
+            project.logger.info("[Unimined] adding Curse maven: ${if (beta) backupBetaCurseMaven else backupCurseMaven}")
+        }
+    }
+
     init {
         project.repositories.mavenCentral { repo ->
             repo.content {

--- a/testing/1.21-NeoForged-Fabric/build.gradle
+++ b/testing/1.21-NeoForged-Fabric/build.gradle
@@ -25,17 +25,10 @@ sourceSets {
 }
 
 repositories {
-    mavenCentral()
-    maven {
-        url = "https://files.minecraftforge.net/maven"
-    }
-    maven {
-        name = "sponge"
-        url = "https://repo.spongepowered.org/maven"
-    }
-    maven {
-        url = "https://maven.wagyourtail.xyz/releases"
-    }
+    unimined.neoForgedMaven()
+    unimined.spongeMaven()
+    unimined.wagYourMaven("releases")
+    unimined.modrinthMaven()
 }
 
 unimined.minecraft {
@@ -86,6 +79,8 @@ configurations {
 dependencies {
     // we need this in main where it isn't by default
     implementation "org.spongepowered:mixin:0.8.5-SNAPSHOT"
+
+    fabricModImplementation("maven.modrinth:lazydfu:0.1.3")
 }
 
 jar {


### PR DESCRIPTION
adds `unimined.modrinthMaven()`, `unimined.curseMaven()`, and `unimined.curseMaven(beta = true)`

not extensively tested but I depended on a mod in the `1.21-NeoForged-Fabric` testing project and it worked