### PR TITLE
Make AT/AW convertor usable

### DIFF
--- a/src/api/kotlin/xyz/wagyourtail/unimined/api/minecraft/patch/ataw/AccessConvert.kt
+++ b/src/api/kotlin/xyz/wagyourtail/unimined/api/minecraft/patch/ataw/AccessConvert.kt
@@ -1,6 +1,5 @@
 package xyz.wagyourtail.unimined.api.minecraft.patch.ataw
 
-import xyz.wagyourtail.unimined.mapping.Namespace
 import java.io.File
 
 /**
@@ -57,7 +56,7 @@ interface AccessConvert {
     /*
      * merge access wideners to an output file
      */
-    fun mergeAws(namespace: Namespace, inputs: List<File>): File
+    fun mergeAws(inputs: List<File>, namespace: String): File
 
     /*
      * merge access wideners to an output file
@@ -67,17 +66,12 @@ interface AccessConvert {
     /*
      * merge access wideners to an output file
      */
-    fun mergeAws(output: File, namespace: Namespace, inputs: List<File>): File
+    fun mergeAws(output: File, inputs: List<File>, namespace: String): File
 
     /**
      * convert access transformer to access widener.
      */
-    fun at2aw(input: String, output: String, namespace: Namespace): File
-
-    /**
-     * convert access transformer to access widener.
-     */
-    fun at2aw(input: String, namespace: Namespace): File
+    fun at2aw(input: String, output: String, namespace: String): File
 
     /**
      * convert access transformer to access widener.
@@ -97,7 +91,7 @@ interface AccessConvert {
     /**
      * convert access transformer to access widener.
      */
-    fun at2aw(input: File, namespace: Namespace): File
+    fun at2aw(input: File, namespace: String): File
 
     /**
      * convert access transformer to access widener.
@@ -107,5 +101,5 @@ interface AccessConvert {
     /**
      * convert access transformer to access widener.
      */
-    fun at2aw(input: File, output: File, namespace: Namespace): File
+    fun at2aw(input: File, output: File, namespace: String): File
 }

--- a/src/mapping/kotlin/xyz/wagyourtail/unimined/internal/mapping/at/AccessTransformerApplier.kt
+++ b/src/mapping/kotlin/xyz/wagyourtail/unimined/internal/mapping/at/AccessTransformerApplier.kt
@@ -7,6 +7,7 @@ import okio.buffer
 import okio.sink
 import okio.use
 import org.gradle.api.logging.Logger
+import xyz.wagyourtail.unimined.mapping.EnvType
 import xyz.wagyourtail.unimined.mapping.Namespace
 import xyz.wagyourtail.unimined.mapping.formats.at.ATReader
 import xyz.wagyourtail.unimined.mapping.formats.at.ATWriter
@@ -60,9 +61,9 @@ object AccessTransformerApplier {
         val temp = noAccessMappings(mappings)
         runBlocking {
             if (isLegacy) {
-                LegacyATReader.read(at.readText(), temp)
+                LegacyATReader.read(at.readText(), temp, envType = EnvType.JOINED, mapOf("source" to namespace))
             } else {
-                ATReader.read(at.readText(), temp)
+                ATReader.read(at.readText(), temp, envType = EnvType.JOINED, mapOf("source" to namespace))
             }
         }
         output.sink().buffer().use {

--- a/src/minecraft/kotlin/xyz/wagyourtail/unimined/internal/minecraft/patch/access/AccessConvertImpl.kt
+++ b/src/minecraft/kotlin/xyz/wagyourtail/unimined/internal/minecraft/patch/access/AccessConvertImpl.kt
@@ -54,21 +54,21 @@ class AccessConvertImpl(val project: Project, val provider: MinecraftProvider) :
         output
     }
 
-    override fun at2aw(input: String, output: String, namespace: Namespace) =
+    override fun at2aw(input: String, output: String, namespace: String) =
         at2aw(File(input), File(output), namespace)
 
-    override fun at2aw(input: String, namespace: Namespace) = at2aw(File(input), namespace)
     override fun at2aw(input: String, output: String) = at2aw(File(input), File(output))
     override fun at2aw(input: String) = at2aw(File(input))
-    override fun at2aw(input: File) = at2aw(input, provider.mappings.devNamespace)
-    override fun at2aw(input: File, namespace: Namespace) = at2aw(
+    override fun at2aw(input: File) = at2aw(input, provider.mappings.devNamespace.name)
+    override fun at2aw(input: File, namespace: String) = at2aw(
         input,
         provider.sourceSet.resources.srcDirs.first().resolve("${project.name.withSourceSet(provider.sourceSet)}.accesswidener"),
         namespace
     )
 
     override fun at2aw(input: File, output: File) = at2aw(input, output, provider.mappings.devNamespace)
-    override fun at2aw(input: File, output: File, namespace: Namespace): File {
+    override fun at2aw(input: File, output: File, namespace: String): File = at2aw(input, output, Namespace(namespace))
+    private fun at2aw(input: File, output: File, namespace: Namespace): File {
         return runBlocking {
             AccessTransformerApplier.at2aw(
                 input.toPath(),
@@ -83,16 +83,16 @@ class AccessConvertImpl(val project: Project, val provider: MinecraftProvider) :
 
     override fun mergeAws(inputs: List<File>): File {
         return mergeAws(
-            provider.mappings.devNamespace,
-            inputs
+            inputs,
+            provider.mappings.devNamespace.name
         )
     }
 
-    override fun mergeAws(namespace: Namespace, inputs: List<File>): File {
+    override fun mergeAws(inputs: List<File>, namespace: String): File {
         return mergeAws(
             provider.sourceSet.resources.srcDirs.first().resolve("${project.name.withSourceSet(provider.sourceSet)}.accesswidener"),
-            namespace,
-            inputs
+            inputs,
+            namespace
         )
     }
 
@@ -100,7 +100,11 @@ class AccessConvertImpl(val project: Project, val provider: MinecraftProvider) :
         return mergeAws(output, provider.mappings.devNamespace, inputs)
     }
 
-    override fun mergeAws(output: File, namespace: Namespace, inputs: List<File>): File {
+    override fun mergeAws(output: File, inputs: List<File>, namespace: String): File {
+        return mergeAws(output, Namespace(namespace), inputs)
+    }
+
+    private fun mergeAws(output: File, namespace: Namespace, inputs: List<File>): File {
         return AccessWidenerApplier.mergeAws(
             inputs.map { it.toPath() },
             output.toPath(),


### PR DESCRIPTION
I realized we were exposing private types in the API. Making said API unusable, so now it is fixed.
Also I made sure the same namespace is used when converting AT to AW, as AT's was defaulting to "source" always.