### PR TITLE
Wisp Forest Maven & Nostalgia Mappings

### DIFF
--- a/src/api/kotlin/xyz/wagyourtail/unimined/api/UniminedExtension.kt
+++ b/src/api/kotlin/xyz/wagyourtail/unimined/api/UniminedExtension.kt
@@ -255,6 +255,7 @@ abstract class UniminedExtension(val project: Project) {
     @Deprecated("Use glassLauncherMaven(\"babric\") instead", ReplaceWith("glassLauncherMaven(\"babric\")"))
     abstract fun babricMaven()
     abstract fun glassLauncherMaven(name: String)
+    abstract fun wispForestMaven(name: String = "releases")
     abstract fun parchmentMaven()
 
     abstract fun neoForgedMaven()

--- a/src/api/kotlin/xyz/wagyourtail/unimined/api/mapping/MappingsConfig.kt
+++ b/src/api/kotlin/xyz/wagyourtail/unimined/api/mapping/MappingsConfig.kt
@@ -349,6 +349,38 @@ abstract class MappingsConfig<T: MappingResolver<T>>(val project: Project, val m
         }
     }
 
+    @JvmOverloads
+    fun nostalgia(
+        build: String,
+        key: String = "nostalgia",
+        @DelegatesTo(value = MappingEntry::class, strategy = Closure.DELEGATE_FIRST)
+        action: Closure<*>
+    ) {
+        nostalgia(build.toInt(), key, action)
+    }
+
+    @JvmOverloads
+    abstract fun nostalgia(build: Int, key: String = "nostalgia", action: MappingEntry.() -> Unit = {})
+
+    @JvmOverloads
+    fun nostalgia(build: String, key: String = "nostalgia", action: MappingEntry.() -> Unit = {}) {
+        nostalgia(build.toInt(), key, action)
+    }
+
+    @JvmOverloads
+    fun nostalgia(
+        build: Int,
+        key: String = "nostalgia",
+        @DelegatesTo(value = MappingEntry::class, strategy = Closure.DELEGATE_FIRST)
+        action: Closure<*>
+    ) {
+        nostalgia(build, key) {
+            action.delegate = this
+            action.resolveStrategy = Closure.DELEGATE_FIRST
+            action.call()
+        }
+    }
+
 
     @JvmOverloads
     abstract fun quilt(build: Int, key: String = "quilt", action: MappingEntry.() -> Unit = {})

--- a/src/main/kotlin/xyz/wagyourtail/unimined/UniminedExtensionImpl.kt
+++ b/src/main/kotlin/xyz/wagyourtail/unimined/UniminedExtensionImpl.kt
@@ -174,6 +174,17 @@ open class UniminedExtensionImpl(project: Project) : UniminedExtension(project) 
         project.logger.info("[Unimined] adding Glass Launcher maven: ${glassLauncherMaven[name]}")
     }
 
+    val wispForestMaven = defaultedMapOf<String, MavenArtifactRepository> { name ->
+        project.repositories.maven {
+            it.name = "Wisp Forest"
+            it.url = URI.create("https://maven.wispforest.io/$name")
+        }
+    }
+
+    override fun wispForestMaven(name: String) {
+        project.logger.info("[Unimined] adding Wisp Forest maven: ${wispForestMaven[name]}")
+    }
+
     val wagYourMaven = defaultedMapOf<String, MavenArtifactRepository> { name ->
         project.repositories.maven {
             it.name = "WagYourTail (${name.capitalized()})"

--- a/src/mapping/kotlin/xyz/wagyourtail/unimined/internal/mapping/MappingsProvider.kt
+++ b/src/mapping/kotlin/xyz/wagyourtail/unimined/internal/mapping/MappingsProvider.kt
@@ -461,7 +461,25 @@ class MappingsProvider(project: Project, minecraft: MinecraftConfig, subKey: Str
         }
     }
 
-    
+    override fun nostalgia(build: Int, key: String, action: MappingEntry.() -> Unit) {
+        unimined.wispForestMaven()
+        val entry = MappingEntry(contentOf(
+            MavenCoords(
+                "me.alphamode",
+                "nostalgia",
+                "${minecraft.version}+build.$build",
+            )), "$key-$build"
+        ).apply {
+            requires("babricIntermediary")
+            provides("nostalgia" to true)
+            action()
+        }
+        addDependency(key, entry)
+        afterLoad.add {
+            renest(entry.requires.name, *entry.provides.map { it.first.name }.toTypedArray())
+        }
+    }
+
     override fun quilt(build: Int, key: String, action: MappingEntry.() -> Unit) {
         unimined.quiltMaven()
         val entry = MappingEntry(contentOf(


### PR DESCRIPTION
Quick and dirty support for Nostalgia mappings. I'm not going to add a test right now.

Simplifies [this](https://github.com/Nolij/Zume/blob/71ed4c107a54ed99c69f2d68d3fd5741e1180c71/primitive/build.gradle.kts#L36) type of buildscript.

Also, the conversion from int to string is backwards, but that's 100% on-brand for Unimined currently.