### PR TITLE
sources jar remapping

### DIFF
--- a/src/api/kotlin/xyz/wagyourtail/unimined/api/minecraft/MinecraftConfig.kt
+++ b/src/api/kotlin/xyz/wagyourtail/unimined/api/minecraft/MinecraftConfig.kt
@@ -20,7 +20,9 @@ import xyz.wagyourtail.unimined.api.minecraft.resolver.MinecraftData
 import xyz.wagyourtail.unimined.api.mod.ModsConfig
 import xyz.wagyourtail.unimined.api.runs.RunsConfig
 import xyz.wagyourtail.unimined.api.source.SourceConfig
+import xyz.wagyourtail.unimined.api.minecraft.task.AbstractRemapJarTask
 import xyz.wagyourtail.unimined.api.minecraft.task.RemapJarTask
+import xyz.wagyourtail.unimined.api.minecraft.task.RemapSourcesJarTask
 import xyz.wagyourtail.unimined.api.unimined
 import xyz.wagyourtail.unimined.util.*
 import java.io.File
@@ -269,7 +271,7 @@ abstract class MinecraftConfig(val project: Project, val sourceSet: SourceSet) :
     /**
      * @since 1.3.10
      */
-    fun remapSources(task: Task, action: RemapJarTask.() -> Unit) {
+    fun remapSources(task: Task, action: RemapSourcesJarTask.() -> Unit) {
         remapSources(task, "remap${task.name.capitalized()}", action)
     }
 
@@ -278,7 +280,7 @@ abstract class MinecraftConfig(val project: Project, val sourceSet: SourceSet) :
      */
     fun remapSources(
         task: Task,
-        @DelegatesTo(value = RemapJarTask::class, strategy = Closure.DELEGATE_FIRST)
+        @DelegatesTo(value = RemapSourcesJarTask::class, strategy = Closure.DELEGATE_FIRST)
         action: Closure<*>
     ) {
         remapSources(task) {
@@ -298,7 +300,7 @@ abstract class MinecraftConfig(val project: Project, val sourceSet: SourceSet) :
     /**
      * @since 1.3.10
      */
-    abstract fun remapSources(task: Task, name: String, action: RemapJarTask.() -> Unit)
+    abstract fun remapSources(task: Task, name: String, action: RemapSourcesJarTask.() -> Unit)
 
     /**
      * @since 1.3.10
@@ -306,7 +308,7 @@ abstract class MinecraftConfig(val project: Project, val sourceSet: SourceSet) :
     fun remapSources(
         task: Task,
         name: String,
-        @DelegatesTo(value = RemapJarTask::class, strategy = Closure.DELEGATE_FIRST)
+        @DelegatesTo(value = RemapSourcesJarTask::class, strategy = Closure.DELEGATE_FIRST)
         action: Closure<*>
     ) {
         remapSources(task, name) {

--- a/src/api/kotlin/xyz/wagyourtail/unimined/api/minecraft/MinecraftConfig.kt
+++ b/src/api/kotlin/xyz/wagyourtail/unimined/api/minecraft/MinecraftConfig.kt
@@ -259,14 +259,23 @@ abstract class MinecraftConfig(val project: Project, val sourceSet: SourceSet) :
         }
     }
 
+    /**
+     * @since 1.3.10
+     */
     fun remapSources(task: Task) {
         remapSources(task) {}
     }
 
+    /**
+     * @since 1.3.10
+     */
     fun remapSources(task: Task, action: RemapJarTask.() -> Unit) {
         remapSources(task, "remap${task.name.capitalized()}", action)
     }
 
+    /**
+     * @since 1.3.10
+     */
     fun remapSources(
         task: Task,
         @DelegatesTo(value = RemapJarTask::class, strategy = Closure.DELEGATE_FIRST)
@@ -279,12 +288,21 @@ abstract class MinecraftConfig(val project: Project, val sourceSet: SourceSet) :
         }
     }
 
+    /**
+     * @since 1.3.10
+     */
     fun remapSources(task: Task, name: String) {
         remapSources(task, name) {}
     }
 
+    /**
+     * @since 1.3.10
+     */
     abstract fun remapSources(task: Task, name: String, action: RemapJarTask.() -> Unit)
 
+    /**
+     * @since 1.3.10
+     */
     fun remapSources(
         task: Task,
         name: String,

--- a/src/api/kotlin/xyz/wagyourtail/unimined/api/minecraft/MinecraftConfig.kt
+++ b/src/api/kotlin/xyz/wagyourtail/unimined/api/minecraft/MinecraftConfig.kt
@@ -9,7 +9,6 @@ import org.gradle.api.Task
 import org.gradle.api.artifacts.Configuration
 import org.gradle.api.artifacts.ModuleDependency
 import org.gradle.api.tasks.SourceSet
-import org.gradle.configurationcache.extensions.capitalized
 import org.intellij.lang.annotations.Language
 import org.jetbrains.annotations.ApiStatus
 import xyz.wagyourtail.unimined.api.mapping.MappingNamespaceTree
@@ -23,10 +22,7 @@ import xyz.wagyourtail.unimined.api.runs.RunsConfig
 import xyz.wagyourtail.unimined.api.source.SourceConfig
 import xyz.wagyourtail.unimined.api.minecraft.task.RemapJarTask
 import xyz.wagyourtail.unimined.api.unimined
-import xyz.wagyourtail.unimined.util.FinalizeOnRead
-import xyz.wagyourtail.unimined.util.LazyMutable
-import xyz.wagyourtail.unimined.util.MustSet
-import xyz.wagyourtail.unimined.util.sourceSets
+import xyz.wagyourtail.unimined.util.*
 import java.io.File
 import java.nio.file.Path
 
@@ -186,7 +182,7 @@ abstract class MinecraftConfig(val project: Project, val sourceSet: SourceSet) :
             val proj = this.project.project(path)
             combineWith(proj, proj.sourceSets.getByName(name))
         }
-    };
+    }
 
     /**
      * the minecraft version to use
@@ -257,6 +253,45 @@ abstract class MinecraftConfig(val project: Project, val sourceSet: SourceSet) :
         action: Closure<*>
     ) {
         remap(task, name) {
+            action.delegate = this
+            action.resolveStrategy = Closure.DELEGATE_FIRST
+            action.call()
+        }
+    }
+
+    fun remapSources(task: Task) {
+        remapSources(task) {}
+    }
+
+    fun remapSources(task: Task, action: RemapJarTask.() -> Unit) {
+        remapSources(task, "remap${task.name.capitalized()}", action)
+    }
+
+    fun remapSources(
+        task: Task,
+        @DelegatesTo(value = RemapJarTask::class, strategy = Closure.DELEGATE_FIRST)
+        action: Closure<*>
+    ) {
+        remapSources(task) {
+            action.delegate = this
+            action.resolveStrategy = Closure.DELEGATE_FIRST
+            action.call()
+        }
+    }
+
+    fun remapSources(task: Task, name: String) {
+        remapSources(task, name) {}
+    }
+
+    abstract fun remapSources(task: Task, name: String, action: RemapJarTask.() -> Unit)
+
+    fun remapSources(
+        task: Task,
+        name: String,
+        @DelegatesTo(value = RemapJarTask::class, strategy = Closure.DELEGATE_FIRST)
+        action: Closure<*>
+    ) {
+        remapSources(task, name) {
             action.delegate = this
             action.resolveStrategy = Closure.DELEGATE_FIRST
             action.call()

--- a/src/api/kotlin/xyz/wagyourtail/unimined/api/minecraft/patch/MinecraftPatcher.kt
+++ b/src/api/kotlin/xyz/wagyourtail/unimined/api/minecraft/patch/MinecraftPatcher.kt
@@ -6,8 +6,7 @@ import org.gradle.api.file.FileCollection
 import org.jetbrains.annotations.ApiStatus
 import org.objectweb.asm.tree.ClassNode
 import xyz.wagyourtail.unimined.api.mapping.MappingNamespaceTree
-import xyz.wagyourtail.unimined.api.minecraft.task.RemapJarTask
-import java.nio.file.FileSystem
+import xyz.wagyourtail.unimined.api.minecraft.task.AbstractRemapJarTask
 import java.nio.file.Path
 
 /**
@@ -47,10 +46,10 @@ interface MinecraftPatcher {
     }
 
     @ApiStatus.Internal
-    fun beforeRemapJarTask(remapJarTask: RemapJarTask, input: Path): Path
+    fun beforeRemapJarTask(remapJarTask: AbstractRemapJarTask, input: Path): Path
 
     @ApiStatus.Internal
-    fun afterRemapJarTask(remapJarTask: RemapJarTask, output: Path)
+    fun afterRemapJarTask(remapJarTask: AbstractRemapJarTask, output: Path)
 
     @get:ApiStatus.Internal
     @set:ApiStatus.Experimental
@@ -61,7 +60,7 @@ interface MinecraftPatcher {
     var unprotectRuntime: Boolean
 
     @ApiStatus.Internal
-    fun configureRemapJar(task: RemapJarTask)
+    fun configureRemapJar(task: AbstractRemapJarTask)
 
     @ApiStatus.Internal
     fun createSourcesJar(classpath: FileCollection, patchedJar: Path, outputPath: Path, linemappedPath: Path?)

--- a/src/api/kotlin/xyz/wagyourtail/unimined/api/minecraft/task/AbstractRemapJarTask.kt
+++ b/src/api/kotlin/xyz/wagyourtail/unimined/api/minecraft/task/AbstractRemapJarTask.kt
@@ -1,0 +1,74 @@
+package xyz.wagyourtail.unimined.api.minecraft.task
+
+import groovy.lang.Closure
+import groovy.lang.DelegatesTo
+import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.InputFile
+import org.gradle.api.tasks.Internal
+import org.gradle.api.tasks.Optional
+import org.gradle.api.tasks.bundling.Jar
+import org.jetbrains.annotations.ApiStatus
+import xyz.wagyourtail.unimined.api.mapping.MappingNamespaceTree
+import xyz.wagyourtail.unimined.api.mapping.mixin.MixinRemapOptions
+import xyz.wagyourtail.unimined.util.FinalizeOnRead
+
+/**
+ * task responsible for transforming your built jar to production.
+ * @since 0.1.0
+ */
+@Suppress("LeakingThis")
+abstract class AbstractRemapJarTask : Jar() {
+
+    @get:InputFile
+    abstract val inputFile: RegularFileProperty
+
+    @get:Internal
+    @set:Internal
+    var devNamespace: MappingNamespaceTree.Namespace? by FinalizeOnRead(null)
+
+    @get:Internal
+    @set:Internal
+    var devFallbackNamespace: MappingNamespaceTree.Namespace? by FinalizeOnRead(null)
+
+    @get:Internal
+    @set:Internal
+    var prodNamespace: MappingNamespaceTree.Namespace? by FinalizeOnRead(null)
+
+    /**
+     * whether to remap AccessTransformers to the legacy format (<=1.7.10)
+     */
+    @get:Input
+    @get:Optional
+    abstract val remapATToLegacy: Property<Boolean?>
+
+    @get:Internal
+    @set:Internal
+    @set:ApiStatus.Experimental
+    abstract var allowImplicitWildcards: Boolean
+
+    abstract fun devNamespace(namespace: String)
+
+    abstract fun devFallbackNamespace(namespace: String)
+
+    abstract fun prodNamespace(namespace: String)
+
+    abstract fun mixinRemap(action: MixinRemapOptions.() -> Unit)
+
+    fun mixinRemap(
+        @DelegatesTo(value = MixinRemapOptions::class, strategy = Closure.DELEGATE_FIRST)
+        action: Closure<*>
+    ) {
+        mixinRemap {
+            action.delegate = this
+            action.resolveStrategy = Closure.DELEGATE_FIRST
+            action.call()
+        }
+    }
+
+    init {
+        remapATToLegacy.convention(null as Boolean?).finalizeValueOnRead()
+    }
+
+}

--- a/src/api/kotlin/xyz/wagyourtail/unimined/api/minecraft/task/RemapSourcesJarTask.kt
+++ b/src/api/kotlin/xyz/wagyourtail/unimined/api/minecraft/task/RemapSourcesJarTask.kt
@@ -2,4 +2,4 @@ package xyz.wagyourtail.unimined.api.minecraft.task
 
 import xyz.wagyourtail.unimined.util.JarInterface
 
-interface RemapJarTask : JarInterface<AbstractRemapJarTask>
+interface RemapSourcesJarTask : JarInterface<AbstractRemapJarTask>

--- a/src/api/kotlin/xyz/wagyourtail/unimined/api/source/remapper/SourceRemapper.kt
+++ b/src/api/kotlin/xyz/wagyourtail/unimined/api/source/remapper/SourceRemapper.kt
@@ -4,6 +4,7 @@ import groovy.lang.Closure
 import groovy.lang.DelegatesTo
 import org.gradle.api.artifacts.Dependency
 import org.gradle.api.file.FileCollection
+import org.gradle.process.JavaExecSpec
 import org.jetbrains.annotations.ApiStatus
 import xyz.wagyourtail.unimined.api.mapping.MappingNamespaceTree
 import java.nio.file.Path
@@ -46,6 +47,7 @@ interface SourceRemapper {
         source: MappingNamespaceTree.Namespace,
         sourceFallback: MappingNamespaceTree.Namespace,
         targetFallback: MappingNamespaceTree.Namespace,
-        target: MappingNamespaceTree.Namespace
+        target: MappingNamespaceTree.Namespace,
+        specConfig: JavaExecSpec.() -> Unit = {}
     )
 }

--- a/src/api/kotlin/xyz/wagyourtail/unimined/api/source/remapper/SourceRemapper.kt
+++ b/src/api/kotlin/xyz/wagyourtail/unimined/api/source/remapper/SourceRemapper.kt
@@ -2,7 +2,7 @@ package xyz.wagyourtail.unimined.api.source.remapper
 
 import groovy.lang.Closure
 import groovy.lang.DelegatesTo
-import org.gradle.api.artifacts.Dependency
+import org.gradle.api.artifacts.ExternalModuleDependency
 import org.gradle.api.file.FileCollection
 import org.gradle.process.JavaExecSpec
 import org.jetbrains.annotations.ApiStatus
@@ -26,11 +26,11 @@ interface SourceRemapper {
      * set the remapper to use (defaults to https://github.com/unimined/source-remap)
      * @since 1.2.0
      */
-    fun remapper(dep: Any, action: Dependency.() -> Unit)
+    fun remapper(dep: Any, action: ExternalModuleDependency.() -> Unit)
 
     fun remapper(
         dep: Any,
-        @DelegatesTo(value = Dependency::class, strategy = Closure.DELEGATE_FIRST)
+        @DelegatesTo(value = ExternalModuleDependency::class, strategy = Closure.DELEGATE_FIRST)
         action: Closure<*>
     ) {
         remapper(dep) {

--- a/src/api/kotlin/xyz/wagyourtail/unimined/api/source/task/MigrateMappingsTask.kt
+++ b/src/api/kotlin/xyz/wagyourtail/unimined/api/source/task/MigrateMappingsTask.kt
@@ -24,9 +24,6 @@ abstract class MigrateMappingsTask : ConventionTask() {
 
     @get:Input
     abstract val commonNamespace: Property<String>
-    init {
-        project.unimined.wagYourMaven("snapshots")
-    }
 
     /**
      * set the target version/mappings to migrate to.

--- a/src/api/kotlin/xyz/wagyourtail/unimined/util/JarInterface.kt
+++ b/src/api/kotlin/xyz/wagyourtail/unimined/util/JarInterface.kt
@@ -1,0 +1,29 @@
+package xyz.wagyourtail.unimined.util
+
+import groovy.lang.Closure
+import groovy.lang.DelegatesTo
+import org.gradle.api.Task
+import org.gradle.api.tasks.Internal
+import org.gradle.api.tasks.bundling.Jar
+
+interface JarInterface<T : Jar> : Task {
+
+    @Suppress("UNCHECKED_CAST")
+    val asJar: T
+        @Internal
+        get() = this as T
+
+    fun asJar(action: T.() -> Unit) {
+        asJar.action()
+    }
+
+    fun asJar(
+        @DelegatesTo(Jar::class, strategy = Closure.DELEGATE_FIRST)
+        closure: Closure<*>
+    ) {
+        asJar {
+            closure.delegate = this
+            closure.call()
+        }
+    }
+}

--- a/src/main/kotlin/xyz/wagyourtail/unimined/UniminedPlugin.kt
+++ b/src/main/kotlin/xyz/wagyourtail/unimined/UniminedPlugin.kt
@@ -2,6 +2,8 @@ package xyz.wagyourtail.unimined
 
 import org.gradle.api.Plugin
 import org.gradle.api.Project
+import xyz.wagyourtail.unimined.internal.minecraft.task.RemapSourcesJarTaskImpl
+import xyz.wagyourtail.unimined.util.sourceSets
 
 class UniminedPlugin: Plugin<Project> {
 
@@ -41,6 +43,12 @@ class UniminedPlugin: Plugin<Project> {
         )
 
         project.extensions.create("unimined", UniminedExtensionImpl::class.java, project)
+
+        project.afterEvaluate {
+            it.sourceSets.forEach { s ->
+                RemapSourcesJarTaskImpl.setup(s, it)
+            }
+        }
     }
 
 }

--- a/src/main/kotlin/xyz/wagyourtail/unimined/UniminedPlugin.kt
+++ b/src/main/kotlin/xyz/wagyourtail/unimined/UniminedPlugin.kt
@@ -2,8 +2,6 @@ package xyz.wagyourtail.unimined
 
 import org.gradle.api.Plugin
 import org.gradle.api.Project
-import xyz.wagyourtail.unimined.internal.minecraft.task.RemapSourcesJarTaskImpl
-import xyz.wagyourtail.unimined.util.sourceSets
 
 class UniminedPlugin: Plugin<Project> {
 
@@ -43,12 +41,6 @@ class UniminedPlugin: Plugin<Project> {
         )
 
         project.extensions.create("unimined", UniminedExtensionImpl::class.java, project)
-
-        project.afterEvaluate {
-            it.sourceSets.forEach { s ->
-                RemapSourcesJarTaskImpl.setup(s, it)
-            }
-        }
     }
 
 }

--- a/src/minecraft/kotlin/xyz/wagyourtail/unimined/internal/minecraft/patch/AbstractMinecraftTransformer.kt
+++ b/src/minecraft/kotlin/xyz/wagyourtail/unimined/internal/minecraft/patch/AbstractMinecraftTransformer.kt
@@ -15,7 +15,7 @@ import xyz.wagyourtail.unimined.api.minecraft.MinecraftConfig
 import xyz.wagyourtail.unimined.api.minecraft.MinecraftJar
 import xyz.wagyourtail.unimined.api.minecraft.patch.MinecraftPatcher
 import xyz.wagyourtail.unimined.api.runs.RunConfig
-import xyz.wagyourtail.unimined.api.minecraft.task.RemapJarTask
+import xyz.wagyourtail.unimined.api.minecraft.task.AbstractRemapJarTask
 import xyz.wagyourtail.unimined.api.unimined
 import xyz.wagyourtail.unimined.api.uniminedMaybe
 import xyz.wagyourtail.unimined.internal.minecraft.MinecraftProvider
@@ -212,12 +212,12 @@ abstract class AbstractMinecraftTransformer protected constructor(
         return baseMinecraft
     }
 
-    override fun beforeRemapJarTask(remapJarTask: RemapJarTask, input: Path): Path {
+    override fun beforeRemapJarTask(remapJarTask: AbstractRemapJarTask, input: Path): Path {
         return input
     }
 
     @ApiStatus.Internal
-    override fun afterRemapJarTask(remapJarTask: RemapJarTask, output: Path) {
+    override fun afterRemapJarTask(remapJarTask: AbstractRemapJarTask, output: Path) {
         // do nothing
     }
 
@@ -292,7 +292,7 @@ abstract class AbstractMinecraftTransformer protected constructor(
         output[sourceSet] = out
     }
 
-    override fun configureRemapJar(task: RemapJarTask) {}
+    override fun configureRemapJar(task: AbstractRemapJarTask) {}
 
     override fun createSourcesJar(classpath: FileCollection, patchedJar: Path, outputPath: Path, linemappedPath: Path?) {
         provider.sourceProvider.sourceGenerator.generate(provider.sourceSet.compileClasspath, patchedJar, outputPath, linemappedPath)

--- a/src/minecraft/kotlin/xyz/wagyourtail/unimined/internal/minecraft/patch/fabric/FabricLikeMinecraftTransformer.kt
+++ b/src/minecraft/kotlin/xyz/wagyourtail/unimined/internal/minecraft/patch/fabric/FabricLikeMinecraftTransformer.kt
@@ -14,7 +14,7 @@ import xyz.wagyourtail.unimined.api.minecraft.patch.ataw.AccessWidenerPatcher
 import xyz.wagyourtail.unimined.api.minecraft.patch.fabric.FabricLikePatcher
 import xyz.wagyourtail.unimined.api.runs.RunConfig
 import xyz.wagyourtail.unimined.api.mapping.task.ExportMappingsTask
-import xyz.wagyourtail.unimined.api.minecraft.task.RemapJarTask
+import xyz.wagyourtail.unimined.api.minecraft.task.AbstractRemapJarTask
 import xyz.wagyourtail.unimined.api.unimined
 import xyz.wagyourtail.unimined.api.uniminedMaybe
 import xyz.wagyourtail.unimined.internal.mapping.ii.InterfaceInjectionMinecraftTransformer
@@ -23,7 +23,6 @@ import xyz.wagyourtail.unimined.internal.minecraft.MinecraftProvider
 import xyz.wagyourtail.unimined.internal.minecraft.patch.AbstractMinecraftTransformer
 import xyz.wagyourtail.unimined.api.minecraft.MinecraftJar
 import xyz.wagyourtail.unimined.internal.minecraft.patch.access.widener.AccessWidenerMinecraftTransformer
-import xyz.wagyourtail.unimined.internal.minecraft.patch.reindev.ReIndevProvider
 import xyz.wagyourtail.unimined.internal.minecraft.resolver.Library
 import xyz.wagyourtail.unimined.internal.minecraft.resolver.parseLibrary
 import xyz.wagyourtail.unimined.internal.minecraft.transform.merge.ClassMerger
@@ -34,10 +33,6 @@ import java.nio.file.Files
 import java.nio.file.Path
 import java.nio.file.StandardCopyOption
 import java.nio.file.StandardOpenOption
-import java.nio.file.attribute.FileTime
-import java.util.concurrent.TimeUnit
-import java.util.zip.ZipEntry
-import java.util.zip.ZipOutputStream
 import kotlin.io.path.*
 
 abstract class FabricLikeMinecraftTransformer(
@@ -321,7 +316,7 @@ abstract class FabricLikeMinecraftTransformer(
         icp
     }
 
-    override fun afterRemapJarTask(remapJarTask: RemapJarTask, output: Path) {
+    override fun afterRemapJarTask(remapJarTask: AbstractRemapJarTask, output: Path) {
         insertIncludes(output)
         insertAW(output)
     }

--- a/src/minecraft/kotlin/xyz/wagyourtail/unimined/internal/minecraft/patch/fabric/FlintMinecraftTransformer.kt
+++ b/src/minecraft/kotlin/xyz/wagyourtail/unimined/internal/minecraft/patch/fabric/FlintMinecraftTransformer.kt
@@ -6,7 +6,7 @@ import org.gradle.api.Project
 import org.gradle.api.artifacts.Dependency
 import xyz.wagyourtail.unimined.api.minecraft.EnvType
 import xyz.wagyourtail.unimined.api.minecraft.MinecraftJar
-import xyz.wagyourtail.unimined.api.minecraft.task.RemapJarTask
+import xyz.wagyourtail.unimined.api.minecraft.task.AbstractRemapJarTask
 import xyz.wagyourtail.unimined.api.runs.RunConfig
 import xyz.wagyourtail.unimined.api.unimined
 import xyz.wagyourtail.unimined.internal.minecraft.MinecraftProvider
@@ -101,7 +101,7 @@ open class FlintMinecraftTransformer(
         throw UnsupportedOperationException("Merging is not supported on flint")
     }
 
-    override fun afterRemapJarTask(remapJarTask: RemapJarTask, output: Path) {
+    override fun afterRemapJarTask(remapJarTask: AbstractRemapJarTask, output: Path) {
         this.insertAccessWidener(output)
     }
 

--- a/src/minecraft/kotlin/xyz/wagyourtail/unimined/internal/minecraft/patch/fabric/LegacyFabricMinecraftTransformer.kt
+++ b/src/minecraft/kotlin/xyz/wagyourtail/unimined/internal/minecraft/patch/fabric/LegacyFabricMinecraftTransformer.kt
@@ -3,7 +3,7 @@ package xyz.wagyourtail.unimined.internal.minecraft.patch.fabric
 import org.gradle.api.Project
 import org.gradle.api.artifacts.Dependency
 import xyz.wagyourtail.unimined.api.minecraft.patch.fabric.LegacyFabricPatcher
-import xyz.wagyourtail.unimined.api.minecraft.task.RemapJarTask
+import xyz.wagyourtail.unimined.api.minecraft.task.AbstractRemapJarTask
 import xyz.wagyourtail.unimined.api.unimined
 import xyz.wagyourtail.unimined.internal.minecraft.MinecraftProvider
 import xyz.wagyourtail.unimined.internal.minecraft.resolver.Library
@@ -35,7 +35,7 @@ open class LegacyFabricMinecraftTransformer(
         project.unimined.legacyFabricMaven()
     }
 
-    override fun configureRemapJar(task: RemapJarTask) {
+    override fun configureRemapJar(task: AbstractRemapJarTask) {
         if (fabricDep.version?.let { SemVerUtils.matches(it, ">=0.15.0") } == true) {
             project.logger.info("enabling mixin extra")
             task.mixinRemap {

--- a/src/minecraft/kotlin/xyz/wagyourtail/unimined/internal/minecraft/patch/fabric/OfficialFabricMinecraftTransformer.kt
+++ b/src/minecraft/kotlin/xyz/wagyourtail/unimined/internal/minecraft/patch/fabric/OfficialFabricMinecraftTransformer.kt
@@ -2,8 +2,7 @@ package xyz.wagyourtail.unimined.internal.minecraft.patch.fabric
 
 import org.gradle.api.Project
 import org.gradle.api.artifacts.Dependency
-import xyz.wagyourtail.unimined.api.minecraft.MinecraftJar
-import xyz.wagyourtail.unimined.api.minecraft.task.RemapJarTask
+import xyz.wagyourtail.unimined.api.minecraft.task.AbstractRemapJarTask
 import xyz.wagyourtail.unimined.internal.minecraft.MinecraftProvider
 import xyz.wagyourtail.unimined.util.SemVerUtils
 
@@ -26,7 +25,7 @@ open class OfficialFabricMinecraftTransformer(
         )
     }
 
-    override fun configureRemapJar(task: RemapJarTask) {
+    override fun configureRemapJar(task: AbstractRemapJarTask) {
         if (fabricDep.version?.let { SemVerUtils.matches(it, ">=0.15.0") } == true) {
             project.logger.info("enabling mixin extra")
             task.mixinRemap {

--- a/src/minecraft/kotlin/xyz/wagyourtail/unimined/internal/minecraft/patch/forge/ForgeLikeMinecraftTransformer.kt
+++ b/src/minecraft/kotlin/xyz/wagyourtail/unimined/internal/minecraft/patch/forge/ForgeLikeMinecraftTransformer.kt
@@ -17,7 +17,7 @@ import xyz.wagyourtail.unimined.api.minecraft.patch.forge.ForgeLikePatcher
 import xyz.wagyourtail.unimined.api.minecraft.patch.ataw.AccessTransformerPatcher
 import xyz.wagyourtail.unimined.api.runs.RunConfig
 import xyz.wagyourtail.unimined.api.mapping.task.ExportMappingsTask
-import xyz.wagyourtail.unimined.api.minecraft.task.RemapJarTask
+import xyz.wagyourtail.unimined.api.minecraft.task.AbstractRemapJarTask
 import xyz.wagyourtail.unimined.api.unimined
 import xyz.wagyourtail.unimined.api.uniminedMaybe
 import xyz.wagyourtail.unimined.internal.mapping.at.AccessTransformerApplier
@@ -33,7 +33,6 @@ import xyz.wagyourtail.unimined.internal.minecraft.transform.merge.ClassMerger
 import xyz.wagyourtail.unimined.util.*
 import java.io.File
 import java.io.InputStreamReader
-import java.nio.file.FileSystem
 import java.nio.file.Path
 import kotlin.io.path.createDirectories
 
@@ -368,7 +367,7 @@ abstract class ForgeLikeMinecraftTransformer(
         }
     }
 
-    override fun afterRemapJarTask(remapJarTask: RemapJarTask, output: Path) {
+    override fun afterRemapJarTask(remapJarTask: AbstractRemapJarTask, output: Path) {
         forgeTransformer.afterRemapJarTask(remapJarTask, output)
     }
 
@@ -392,11 +391,11 @@ abstract class ForgeLikeMinecraftTransformer(
         return forgeTransformer.name()
     }
 
-    override fun beforeRemapJarTask(remapJarTask: RemapJarTask, input: Path): Path {
+    override fun beforeRemapJarTask(remapJarTask: AbstractRemapJarTask, input: Path): Path {
         return forgeTransformer.beforeRemapJarTask(remapJarTask, input)
     }
 
-    override fun configureRemapJar(task: RemapJarTask) {
+    override fun configureRemapJar(task: AbstractRemapJarTask) {
         forgeTransformer.configureRemapJar(task)
     }
 

--- a/src/minecraft/kotlin/xyz/wagyourtail/unimined/internal/minecraft/patch/forge/NeoForgedMinecraftTransformer.kt
+++ b/src/minecraft/kotlin/xyz/wagyourtail/unimined/internal/minecraft/patch/forge/NeoForgedMinecraftTransformer.kt
@@ -4,7 +4,7 @@ import com.google.gson.JsonObject
 import org.gradle.api.Project
 import org.gradle.api.artifacts.Dependency
 import xyz.wagyourtail.unimined.api.minecraft.patch.forge.NeoForgedPatcher
-import xyz.wagyourtail.unimined.api.minecraft.task.RemapJarTask
+import xyz.wagyourtail.unimined.api.minecraft.task.AbstractRemapJarTask
 import xyz.wagyourtail.unimined.api.unimined
 import xyz.wagyourtail.unimined.internal.minecraft.MinecraftProvider
 import xyz.wagyourtail.unimined.internal.minecraft.patch.forge.fg3.FG3MinecraftTransformer
@@ -64,7 +64,7 @@ open class NeoForgedMinecraftTransformer(project: Project, provider: MinecraftPr
         tweakClassClient = args.split("--tweakClass")[1].trim()
     }
 
-    override fun configureRemapJar(task: RemapJarTask) {
+    override fun configureRemapJar(task: AbstractRemapJarTask) {
         val forgeDep = forge.dependencies.first()
         if (provider.version != "1.20.1") {
             project.logger.info("setting `disableRefmap()` in mixinRemap")

--- a/src/minecraft/kotlin/xyz/wagyourtail/unimined/internal/minecraft/patch/forge/fg3/FG3MinecraftTransformer.kt
+++ b/src/minecraft/kotlin/xyz/wagyourtail/unimined/internal/minecraft/patch/forge/fg3/FG3MinecraftTransformer.kt
@@ -16,7 +16,7 @@ import org.jetbrains.annotations.VisibleForTesting
 import xyz.wagyourtail.unimined.*
 import xyz.wagyourtail.unimined.api.minecraft.EnvType
 import xyz.wagyourtail.unimined.api.minecraft.MinecraftJar
-import xyz.wagyourtail.unimined.api.minecraft.task.RemapJarTask
+import xyz.wagyourtail.unimined.api.minecraft.task.AbstractRemapJarTask
 import xyz.wagyourtail.unimined.api.runs.RunConfig
 import xyz.wagyourtail.unimined.api.unimined
 import xyz.wagyourtail.unimined.internal.minecraft.patch.fabric.FabricLikeMinecraftTransformer
@@ -27,7 +27,6 @@ import xyz.wagyourtail.unimined.internal.minecraft.patch.forge.fg3.mcpconfig.Mcp
 import xyz.wagyourtail.unimined.internal.minecraft.patch.forge.fg3.mcpconfig.McpConfigStep
 import xyz.wagyourtail.unimined.internal.minecraft.patch.forge.fg3.mcpconfig.McpExecutor
 import xyz.wagyourtail.unimined.internal.minecraft.patch.jarmod.JarModMinecraftTransformer
-import xyz.wagyourtail.unimined.internal.minecraft.resolver.AssetsDownloader
 import xyz.wagyourtail.unimined.internal.minecraft.transform.fixes.FixFG2ResourceLoading
 import xyz.wagyourtail.unimined.internal.minecraft.transform.merge.ClassMerger
 import xyz.wagyourtail.unimined.util.*
@@ -571,7 +570,7 @@ open class FG3MinecraftTransformer(project: Project, val parent: ForgeLikeMinecr
         })
     }
 
-    private fun doJarJar(remapJarTask: RemapJarTask, output: Path) {
+    private fun doJarJar(remapJarTask: AbstractRemapJarTask, output: Path) {
         if (include!!.dependencies.isEmpty()) {
             return
         }
@@ -606,7 +605,7 @@ open class FG3MinecraftTransformer(project: Project, val parent: ForgeLikeMinecr
         }
     }
 
-    override fun afterRemapJarTask(remapJarTask: RemapJarTask, output: Path) {
+    override fun afterRemapJarTask(remapJarTask: AbstractRemapJarTask, output: Path) {
         if (provider.minecraftData.mcVersionCompare(provider.version, "1.18") >= 0) {
             doJarJar(remapJarTask, output)
         }

--- a/src/minecraft/kotlin/xyz/wagyourtail/unimined/internal/minecraft/patch/jarmod/JarModAgentMinecraftTransformer.kt
+++ b/src/minecraft/kotlin/xyz/wagyourtail/unimined/internal/minecraft/patch/jarmod/JarModAgentMinecraftTransformer.kt
@@ -4,7 +4,7 @@ import org.gradle.api.Project
 import org.gradle.api.artifacts.ExternalDependency
 import xyz.wagyourtail.unimined.api.minecraft.patch.jarmod.JarModAgentPatcher
 import xyz.wagyourtail.unimined.api.runs.RunConfig
-import xyz.wagyourtail.unimined.api.minecraft.task.RemapJarTask
+import xyz.wagyourtail.unimined.api.minecraft.task.AbstractRemapJarTask
 import xyz.wagyourtail.unimined.api.unimined
 import xyz.wagyourtail.unimined.internal.minecraft.MinecraftProvider
 import xyz.wagyourtail.unimined.internal.minecraft.patch.forge.fg3.mcpconfig.SubprocessExecutor
@@ -104,7 +104,7 @@ open class JarModAgentMinecraftTransformer(
         //TODO: add mods to priority classpath, and resolve their jma.transformers
     }
 
-    override fun beforeRemapJarTask(remapJarTask: RemapJarTask, input: Path): Path {
+    override fun beforeRemapJarTask(remapJarTask: AbstractRemapJarTask, input: Path): Path {
         remapJarTask.mixinRemap {
             enableJarModAgent()
         }

--- a/src/minecraft/kotlin/xyz/wagyourtail/unimined/internal/minecraft/patch/merged/MergedMinecraftTransformer.kt
+++ b/src/minecraft/kotlin/xyz/wagyourtail/unimined/internal/minecraft/patch/merged/MergedMinecraftTransformer.kt
@@ -16,7 +16,7 @@ import xyz.wagyourtail.unimined.api.minecraft.patch.forge.NeoForgedPatcher
 import xyz.wagyourtail.unimined.api.minecraft.patch.jarmod.JarModAgentPatcher
 import xyz.wagyourtail.unimined.api.minecraft.patch.rift.RiftPatcher
 import xyz.wagyourtail.unimined.api.runs.RunConfig
-import xyz.wagyourtail.unimined.api.minecraft.task.RemapJarTask
+import xyz.wagyourtail.unimined.api.minecraft.task.AbstractRemapJarTask
 import xyz.wagyourtail.unimined.internal.minecraft.MinecraftProvider
 import xyz.wagyourtail.unimined.internal.minecraft.patch.AbstractMinecraftTransformer
 import xyz.wagyourtail.unimined.api.minecraft.MinecraftJar
@@ -34,8 +34,6 @@ import xyz.wagyourtail.unimined.internal.minecraft.patch.jarmod.JarModAgentMinec
 import xyz.wagyourtail.unimined.internal.minecraft.patch.rift.RiftMinecraftTransformer
 import xyz.wagyourtail.unimined.internal.minecraft.resolver.Library
 import xyz.wagyourtail.unimined.util.FinalizeOnRead
-import xyz.wagyourtail.unimined.util.MustSet
-import java.nio.file.FileSystem
 import java.nio.file.Path
 
 class MergedMinecraftTransformer(project: Project, provider: MinecraftProvider): AbstractMinecraftTransformer(project, provider, "merged"), MergedPatcher {
@@ -77,7 +75,7 @@ class MergedMinecraftTransformer(project: Project, provider: MinecraftProvider):
         }
     }
 
-    override fun beforeRemapJarTask(remapJarTask: RemapJarTask, input: Path): Path {
+    override fun beforeRemapJarTask(remapJarTask: AbstractRemapJarTask, input: Path): Path {
         return patchers.fold(input) {
             acc, patcher -> patcher.beforeRemapJarTask(remapJarTask, acc)
         }
@@ -91,7 +89,7 @@ class MergedMinecraftTransformer(project: Project, provider: MinecraftProvider):
         patchers.forEach { it.afterEvaluate() }
     }
 
-    override fun afterRemapJarTask(remapJarTask: RemapJarTask, output: Path) {
+    override fun afterRemapJarTask(remapJarTask: AbstractRemapJarTask, output: Path) {
         patchers.forEach { it.afterRemapJarTask(remapJarTask, output) }
     }
 

--- a/src/minecraft/kotlin/xyz/wagyourtail/unimined/internal/minecraft/task/AbstractRemapJarTask.kt
+++ b/src/minecraft/kotlin/xyz/wagyourtail/unimined/internal/minecraft/task/AbstractRemapJarTask.kt
@@ -1,0 +1,136 @@
+package xyz.wagyourtail.unimined.internal.minecraft.task
+
+import org.gradle.api.tasks.Internal
+import org.gradle.api.tasks.TaskAction
+import xyz.wagyourtail.unimined.api.mapping.MappingNamespaceTree
+import xyz.wagyourtail.unimined.api.mapping.mixin.MixinRemapOptions
+import xyz.wagyourtail.unimined.api.minecraft.MinecraftConfig
+import xyz.wagyourtail.unimined.api.minecraft.task.RemapJarTask
+import xyz.wagyourtail.unimined.util.FinalizeOnRead
+import xyz.wagyourtail.unimined.util.LazyMutable
+import xyz.wagyourtail.unimined.util.getField
+import xyz.wagyourtail.unimined.util.readZipInputStreamFor
+import java.nio.file.Path
+import java.nio.file.StandardOpenOption
+import javax.inject.Inject
+import kotlin.io.path.*
+
+@Suppress("UNCHECKED_CAST")
+abstract class AbstractRemapJarTask @Inject constructor(@get:Internal val provider: MinecraftConfig): RemapJarTask() {
+
+    @get:Internal
+    protected var mixinRemapOptions: MixinRemapOptions.() -> Unit by FinalizeOnRead {}
+
+    override fun devNamespace(namespace: String) {
+        val delegate: FinalizeOnRead<MappingNamespaceTree.Namespace> = RemapJarTask::class.getField("devNamespace")!!.getDelegate(this) as FinalizeOnRead<MappingNamespaceTree.Namespace>
+        delegate.setValueIntl(LazyMutable { provider.mappings.getNamespace(namespace) })
+    }
+
+    override fun devFallbackNamespace(namespace: String) {
+        val delegate: FinalizeOnRead<MappingNamespaceTree.Namespace> = RemapJarTask::class.getField("devFallbackNamespace")!!.getDelegate(this) as FinalizeOnRead<MappingNamespaceTree.Namespace>
+        delegate.setValueIntl(LazyMutable { provider.mappings.getNamespace(namespace) })
+    }
+
+    override fun prodNamespace(namespace: String) {
+        val delegate: FinalizeOnRead<MappingNamespaceTree.Namespace> = RemapJarTask::class.getField("prodNamespace")!!.getDelegate(this) as FinalizeOnRead<MappingNamespaceTree.Namespace>
+        delegate.setValueIntl(LazyMutable { provider.mappings.getNamespace(namespace) })
+    }
+
+    override fun mixinRemap(action: MixinRemapOptions.() -> Unit) {
+        val delegate: FinalizeOnRead<MixinRemapOptions.() -> Unit> = AbstractRemapJarTask::class.getField("mixinRemapOptions")!!.getDelegate(this) as FinalizeOnRead<MixinRemapOptions.() -> Unit>
+        val old = delegate.value as MixinRemapOptions.() -> Unit
+        mixinRemapOptions = {
+            old()
+            action()
+        }
+    }
+
+    override var allowImplicitWildcards by FinalizeOnRead(false)
+
+    @TaskAction
+    @Suppress("UNNECESSARY_NOT_NULL_ASSERTION")
+    fun run() {
+        val prodNs = prodNamespace ?: provider.mcPatcher.prodNamespace!!
+        val devNs = devNamespace ?: provider.mappings.devNamespace!!
+        val devFNs = devFallbackNamespace ?: provider.mappings.devFallbackNamespace!!
+
+        val path = provider.mappings.getRemapPath(
+            devNs,
+            devFNs,
+            prodNs,
+            prodNs
+        )
+
+        val inputFile = provider.mcPatcher.beforeRemapJarTask(this, inputFile.get().asFile.toPath())
+
+        if (path.isEmpty()) {
+            project.logger.lifecycle("[Unimined/RemapJar ${this.path}] detected empty remap path, jumping to after remap tasks")
+            provider.mcPatcher.afterRemapJarTask(this, inputFile)
+            afterRemap(inputFile)
+            return
+        }
+
+        project.logger.lifecycle("[Unimined/RemapJar ${this.path}] remapping output ${inputFile.name} from $devNs/$devFNs to $prodNs")
+        project.logger.info("[Unimined/RemapJar ${this.path}]    $devNs -> ${path.joinToString(" -> ") { it.name }}")
+
+        var prevTarget = inputFile
+        var prevNamespace = devNs
+        var prevPrevNamespace = devFNs
+        for (i in path.indices) {
+            val step = path[i]
+            project.logger.info("[Unimined/RemapJar ${this.path}]    $step")
+            val nextTarget = temporaryDir.toPath().resolve("${inputFile.nameWithoutExtension}-temp-${step.name}.jar")
+            nextTarget.deleteIfExists()
+
+            val mc = provider.getMinecraft(
+                prevNamespace,
+                prevPrevNamespace
+            )
+            val classpath = provider.mods.getClasspathAs(
+                prevNamespace,
+                prevPrevNamespace,
+                provider.sourceSet.compileClasspath.files
+            ).map { it.toPath() }.filter { it.exists() && !provider.isMinecraftJar(it) }
+
+            project.logger.debug("[Unimined/RemapJar ${path}] classpath: ")
+            classpath.forEach {
+                project.logger.debug("[Unimined/RemapJar ${path}]    $it")
+            }
+
+            doRemap(prevTarget, nextTarget, prevNamespace, step, (classpath + listOf(mc)).toTypedArray())
+
+            prevTarget = nextTarget
+            prevPrevNamespace = prevNamespace
+            prevNamespace = step
+        }
+        project.logger.info("[Unimined/RemapJar ${path}] after remap tasks started ${System.currentTimeMillis()}")
+        provider.mcPatcher.afterRemapJarTask(this, prevTarget)
+        afterRemap(prevTarget)
+        project.logger.info("[Unimined/RemapJar ${path}] after remap tasks finished ${System.currentTimeMillis()}")
+    }
+
+    private fun afterRemap(afterRemapJar: Path) {
+        // merge in manifest from input jar
+        afterRemapJar.readZipInputStreamFor("META-INF/MANIFEST.MF", false) { inp ->
+            // write to temp file
+            val inpTmp = temporaryDir.toPath().resolve("input-manifest.MF")
+            inpTmp.outputStream(StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING).use { out ->
+                inp.copyTo(out)
+            }
+            this.manifest {
+                it.from(inpTmp)
+            }
+        }
+        // copy into output
+        from(project.zipTree(afterRemapJar))
+        copy()
+    }
+
+    protected abstract fun doRemap(
+        from: Path,
+        target: Path,
+        fromNs: MappingNamespaceTree.Namespace,
+        toNs: MappingNamespaceTree.Namespace,
+        classpathList: Array<Path>
+    )
+}

--- a/src/minecraft/kotlin/xyz/wagyourtail/unimined/internal/minecraft/task/AbstractRemapJarTaskImpl.kt
+++ b/src/minecraft/kotlin/xyz/wagyourtail/unimined/internal/minecraft/task/AbstractRemapJarTaskImpl.kt
@@ -5,7 +5,7 @@ import org.gradle.api.tasks.TaskAction
 import xyz.wagyourtail.unimined.api.mapping.MappingNamespaceTree
 import xyz.wagyourtail.unimined.api.mapping.mixin.MixinRemapOptions
 import xyz.wagyourtail.unimined.api.minecraft.MinecraftConfig
-import xyz.wagyourtail.unimined.api.minecraft.task.RemapJarTask
+import xyz.wagyourtail.unimined.api.minecraft.task.AbstractRemapJarTask
 import xyz.wagyourtail.unimined.util.FinalizeOnRead
 import xyz.wagyourtail.unimined.util.LazyMutable
 import xyz.wagyourtail.unimined.util.getField
@@ -16,28 +16,28 @@ import javax.inject.Inject
 import kotlin.io.path.*
 
 @Suppress("UNCHECKED_CAST")
-abstract class AbstractRemapJarTask @Inject constructor(@get:Internal val provider: MinecraftConfig): RemapJarTask() {
+abstract class AbstractRemapJarTaskImpl @Inject constructor(@get:Internal val provider: MinecraftConfig): AbstractRemapJarTask() {
 
     @get:Internal
     protected var mixinRemapOptions: MixinRemapOptions.() -> Unit by FinalizeOnRead {}
 
     override fun devNamespace(namespace: String) {
-        val delegate: FinalizeOnRead<MappingNamespaceTree.Namespace> = RemapJarTask::class.getField("devNamespace")!!.getDelegate(this) as FinalizeOnRead<MappingNamespaceTree.Namespace>
+        val delegate: FinalizeOnRead<MappingNamespaceTree.Namespace> = AbstractRemapJarTask::class.getField("devNamespace")!!.getDelegate(this) as FinalizeOnRead<MappingNamespaceTree.Namespace>
         delegate.setValueIntl(LazyMutable { provider.mappings.getNamespace(namespace) })
     }
 
     override fun devFallbackNamespace(namespace: String) {
-        val delegate: FinalizeOnRead<MappingNamespaceTree.Namespace> = RemapJarTask::class.getField("devFallbackNamespace")!!.getDelegate(this) as FinalizeOnRead<MappingNamespaceTree.Namespace>
+        val delegate: FinalizeOnRead<MappingNamespaceTree.Namespace> = AbstractRemapJarTask::class.getField("devFallbackNamespace")!!.getDelegate(this) as FinalizeOnRead<MappingNamespaceTree.Namespace>
         delegate.setValueIntl(LazyMutable { provider.mappings.getNamespace(namespace) })
     }
 
     override fun prodNamespace(namespace: String) {
-        val delegate: FinalizeOnRead<MappingNamespaceTree.Namespace> = RemapJarTask::class.getField("prodNamespace")!!.getDelegate(this) as FinalizeOnRead<MappingNamespaceTree.Namespace>
+        val delegate: FinalizeOnRead<MappingNamespaceTree.Namespace> = AbstractRemapJarTask::class.getField("prodNamespace")!!.getDelegate(this) as FinalizeOnRead<MappingNamespaceTree.Namespace>
         delegate.setValueIntl(LazyMutable { provider.mappings.getNamespace(namespace) })
     }
 
     override fun mixinRemap(action: MixinRemapOptions.() -> Unit) {
-        val delegate: FinalizeOnRead<MixinRemapOptions.() -> Unit> = AbstractRemapJarTask::class.getField("mixinRemapOptions")!!.getDelegate(this) as FinalizeOnRead<MixinRemapOptions.() -> Unit>
+        val delegate: FinalizeOnRead<MixinRemapOptions.() -> Unit> = AbstractRemapJarTaskImpl::class.getField("mixinRemapOptions")!!.getDelegate(this) as FinalizeOnRead<MixinRemapOptions.() -> Unit>
         val old = delegate.value as MixinRemapOptions.() -> Unit
         mixinRemapOptions = {
             old()

--- a/src/minecraft/kotlin/xyz/wagyourtail/unimined/internal/minecraft/task/RemapJarTaskImpl.kt
+++ b/src/minecraft/kotlin/xyz/wagyourtail/unimined/internal/minecraft/task/RemapJarTaskImpl.kt
@@ -7,6 +7,7 @@ import net.fabricmc.tinyremapper.TinyRemapper
 import xyz.wagyourtail.unimined.api.mapping.MappingNamespaceTree
 import xyz.wagyourtail.unimined.api.minecraft.MinecraftConfig
 import xyz.wagyourtail.unimined.api.minecraft.patch.forge.ForgeLikePatcher
+import xyz.wagyourtail.unimined.api.minecraft.task.RemapJarTask
 import xyz.wagyourtail.unimined.internal.mapping.at.AccessTransformerApplier
 import xyz.wagyourtail.unimined.internal.mapping.aw.AccessWidenerApplier
 import xyz.wagyourtail.unimined.internal.mapping.extension.MixinRemapExtension
@@ -16,7 +17,8 @@ import javax.inject.Inject
 import kotlin.io.path.createDirectories
 import kotlin.io.path.deleteIfExists
 
-abstract class RemapJarTaskImpl @Inject constructor(provider: MinecraftConfig): AbstractRemapJarTask(provider) {
+abstract class RemapJarTaskImpl @Inject constructor(provider: MinecraftConfig):
+    AbstractRemapJarTaskImpl(provider), RemapJarTask {
 
     @Suppress("UNNECESSARY_NOT_NULL_ASSERTION")
     override fun doRemap(

--- a/src/minecraft/kotlin/xyz/wagyourtail/unimined/internal/minecraft/task/RemapJarTaskImpl.kt
+++ b/src/minecraft/kotlin/xyz/wagyourtail/unimined/internal/minecraft/task/RemapJarTaskImpl.kt
@@ -20,6 +20,7 @@ import java.nio.file.StandardOpenOption
 import javax.inject.Inject
 import kotlin.io.path.*
 
+@Suppress("UNCHECKED_CAST")
 abstract class RemapJarTaskImpl @Inject constructor(@get:Internal val provider: MinecraftConfig): RemapJarTask() {
 
     private var mixinRemapOptions: MixinRemapOptions.() -> Unit by FinalizeOnRead {}
@@ -129,7 +130,7 @@ abstract class RemapJarTaskImpl @Inject constructor(@get:Internal val provider: 
     }
 
     @Suppress("UNNECESSARY_NOT_NULL_ASSERTION")
-    protected fun remapToInternal(
+    protected open fun remapToInternal(
         from: Path,
         target: Path,
         fromNs: MappingNamespaceTree.Namespace,

--- a/src/minecraft/kotlin/xyz/wagyourtail/unimined/internal/minecraft/task/RemapJarTaskImpl.kt
+++ b/src/minecraft/kotlin/xyz/wagyourtail/unimined/internal/minecraft/task/RemapJarTaskImpl.kt
@@ -4,134 +4,22 @@ import net.fabricmc.loom.util.kotlin.KotlinClasspathService
 import net.fabricmc.loom.util.kotlin.KotlinRemapperClassloader
 import net.fabricmc.tinyremapper.OutputConsumerPath
 import net.fabricmc.tinyremapper.TinyRemapper
-import org.gradle.api.tasks.Internal
-import org.gradle.api.tasks.TaskAction
 import xyz.wagyourtail.unimined.api.mapping.MappingNamespaceTree
-import xyz.wagyourtail.unimined.api.mapping.mixin.MixinRemapOptions
 import xyz.wagyourtail.unimined.api.minecraft.MinecraftConfig
 import xyz.wagyourtail.unimined.api.minecraft.patch.forge.ForgeLikePatcher
-import xyz.wagyourtail.unimined.api.minecraft.task.RemapJarTask
 import xyz.wagyourtail.unimined.internal.mapping.at.AccessTransformerApplier
 import xyz.wagyourtail.unimined.internal.mapping.aw.AccessWidenerApplier
 import xyz.wagyourtail.unimined.internal.mapping.extension.MixinRemapExtension
-import xyz.wagyourtail.unimined.util.*
+import xyz.wagyourtail.unimined.util.openZipFileSystem
 import java.nio.file.Path
-import java.nio.file.StandardOpenOption
 import javax.inject.Inject
-import kotlin.io.path.*
+import kotlin.io.path.createDirectories
+import kotlin.io.path.deleteIfExists
 
-@Suppress("UNCHECKED_CAST")
-abstract class RemapJarTaskImpl @Inject constructor(@get:Internal val provider: MinecraftConfig): RemapJarTask() {
-
-    private var mixinRemapOptions: MixinRemapOptions.() -> Unit by FinalizeOnRead {}
-
-    override fun devNamespace(namespace: String) {
-        val delegate: FinalizeOnRead<MappingNamespaceTree.Namespace> = RemapJarTask::class.getField("devNamespace")!!.getDelegate(this) as FinalizeOnRead<MappingNamespaceTree.Namespace>
-        delegate.setValueIntl(LazyMutable { provider.mappings.getNamespace(namespace) })
-    }
-
-    override fun devFallbackNamespace(namespace: String) {
-        val delegate: FinalizeOnRead<MappingNamespaceTree.Namespace> = RemapJarTask::class.getField("devFallbackNamespace")!!.getDelegate(this) as FinalizeOnRead<MappingNamespaceTree.Namespace>
-        delegate.setValueIntl(LazyMutable { provider.mappings.getNamespace(namespace) })
-    }
-
-    override fun prodNamespace(namespace: String) {
-        val delegate: FinalizeOnRead<MappingNamespaceTree.Namespace> = RemapJarTask::class.getField("prodNamespace")!!.getDelegate(this) as FinalizeOnRead<MappingNamespaceTree.Namespace>
-        delegate.setValueIntl(LazyMutable { provider.mappings.getNamespace(namespace) })
-    }
-
-    override fun mixinRemap(action: MixinRemapOptions.() -> Unit) {
-        val delegate: FinalizeOnRead<MixinRemapOptions.() -> Unit> = RemapJarTaskImpl::class.getField("mixinRemapOptions")!!.getDelegate(this) as FinalizeOnRead<MixinRemapOptions.() -> Unit>
-        val old = delegate.value as MixinRemapOptions.() -> Unit
-        mixinRemapOptions = {
-            old()
-            action()
-        }
-    }
-
-    override var allowImplicitWildcards by FinalizeOnRead(false)
-
-    @TaskAction
-    @Suppress("UNNECESSARY_NOT_NULL_ASSERTION")
-    fun run() {
-        val prodNs = prodNamespace ?: provider.mcPatcher.prodNamespace!!
-        val devNs = devNamespace ?: provider.mappings.devNamespace!!
-        val devFNs = devFallbackNamespace ?: provider.mappings.devFallbackNamespace!!
-
-        val path = provider.mappings.getRemapPath(
-            devNs,
-            devFNs,
-            prodNs,
-            prodNs
-        )
-
-        val inputFile = provider.mcPatcher.beforeRemapJarTask(this, inputFile.get().asFile.toPath())
-
-        if (path.isEmpty()) {
-            project.logger.lifecycle("[Unimined/RemapJar ${this.path}] detected empty remap path, jumping to after remap tasks")
-            provider.mcPatcher.afterRemapJarTask(this, inputFile)
-            afterRemap(inputFile)
-            return
-        }
-
-        project.logger.lifecycle("[Unimined/RemapJar ${this.path}] remapping output ${inputFile.name} from $devNs/$devFNs to $prodNs")
-        project.logger.info("[Unimined/RemapJar ${this.path}]    $devNs -> ${path.joinToString(" -> ") { it.name }}")
-
-        var prevTarget = inputFile
-        var prevNamespace = devNs
-        var prevPrevNamespace = devFNs
-        for (i in path.indices) {
-            val step = path[i]
-            project.logger.info("[Unimined/RemapJar ${this.path}]    $step")
-            val nextTarget = temporaryDir.toPath().resolve("${inputFile.nameWithoutExtension}-temp-${step.name}.jar")
-            nextTarget.deleteIfExists()
-
-            val mc = provider.getMinecraft(
-                prevNamespace,
-                prevPrevNamespace
-            )
-            val classpath = provider.mods.getClasspathAs(
-                prevNamespace,
-                prevPrevNamespace,
-                provider.sourceSet.compileClasspath.files
-            ).map { it.toPath() }.filter { it.exists() && !provider.isMinecraftJar(it) }
-
-            project.logger.debug("[Unimined/RemapJar ${path}] classpath: ")
-            classpath.forEach {
-                project.logger.debug("[Unimined/RemapJar ${path}]    $it")
-            }
-
-            remapToInternal(prevTarget, nextTarget, prevNamespace, step, (classpath + listOf(mc)).toTypedArray())
-
-            prevTarget = nextTarget
-            prevPrevNamespace = prevNamespace
-            prevNamespace = step
-        }
-        project.logger.info("[Unimined/RemapJar ${path}] after remap tasks started ${System.currentTimeMillis()}")
-        provider.mcPatcher.afterRemapJarTask(this, prevTarget)
-        afterRemap(prevTarget)
-        project.logger.info("[Unimined/RemapJar ${path}] after remap tasks finished ${System.currentTimeMillis()}")
-    }
-
-    private fun afterRemap(afterRemapJar: Path) {
-        // merge in manifest from input jar
-        afterRemapJar.readZipInputStreamFor("META-INF/MANIFEST.MF", false) { inp ->
-            // write to temp file
-            val inpTmp = temporaryDir.toPath().resolve("input-manifest.MF")
-            inpTmp.outputStream(StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING).use { out ->
-                inp.copyTo(out)
-            }
-            this.manifest {
-                it.from(inpTmp)
-            }
-        }
-        // copy into output
-        from(project.zipTree(afterRemapJar))
-        copy()
-    }
+abstract class RemapJarTaskImpl @Inject constructor(provider: MinecraftConfig): AbstractRemapJarTask(provider) {
 
     @Suppress("UNNECESSARY_NOT_NULL_ASSERTION")
-    protected open fun remapToInternal(
+    override fun doRemap(
         from: Path,
         target: Path,
         fromNs: MappingNamespaceTree.Namespace,

--- a/src/minecraft/kotlin/xyz/wagyourtail/unimined/internal/minecraft/task/RemapJarTaskImpl.kt
+++ b/src/minecraft/kotlin/xyz/wagyourtail/unimined/internal/minecraft/task/RemapJarTaskImpl.kt
@@ -76,6 +76,7 @@ abstract class RemapJarTaskImpl @Inject constructor(@get:Internal val provider: 
 
         project.logger.lifecycle("[Unimined/RemapJar ${this.path}] remapping output ${inputFile.name} from $devNs/$devFNs to $prodNs")
         project.logger.info("[Unimined/RemapJar ${this.path}]    $devNs -> ${path.joinToString(" -> ") { it.name }}")
+
         var prevTarget = inputFile
         var prevNamespace = devNs
         var prevPrevNamespace = devFNs

--- a/src/minecraft/kotlin/xyz/wagyourtail/unimined/internal/minecraft/task/RemapSourcesJarTaskImpl.kt
+++ b/src/minecraft/kotlin/xyz/wagyourtail/unimined/internal/minecraft/task/RemapSourcesJarTaskImpl.kt
@@ -2,6 +2,7 @@ package xyz.wagyourtail.unimined.internal.minecraft.task
 
 import xyz.wagyourtail.unimined.api.mapping.MappingNamespaceTree
 import xyz.wagyourtail.unimined.api.minecraft.MinecraftConfig
+import xyz.wagyourtail.unimined.api.minecraft.task.RemapSourcesJarTask
 import xyz.wagyourtail.unimined.util.deleteRecursively
 import java.nio.file.Path
 import java.util.jar.JarEntry
@@ -10,7 +11,8 @@ import java.util.zip.Deflater
 import javax.inject.Inject
 import kotlin.io.path.*
 
-abstract class RemapSourcesJarTaskImpl @Inject constructor(provider: MinecraftConfig): AbstractRemapJarTask(provider) {
+abstract class RemapSourcesJarTaskImpl @Inject constructor(provider: MinecraftConfig):
+    AbstractRemapJarTaskImpl(provider), RemapSourcesJarTask {
     @OptIn(ExperimentalPathApi::class)
     override fun doRemap(
         from: Path,

--- a/src/minecraft/kotlin/xyz/wagyourtail/unimined/internal/minecraft/task/RemapSourcesJarTaskImpl.kt
+++ b/src/minecraft/kotlin/xyz/wagyourtail/unimined/internal/minecraft/task/RemapSourcesJarTaskImpl.kt
@@ -6,6 +6,7 @@ import xyz.wagyourtail.unimined.util.deleteRecursively
 import java.nio.file.Path
 import java.util.jar.JarEntry
 import java.util.jar.JarOutputStream
+import java.util.zip.Deflater
 import javax.inject.Inject
 import kotlin.io.path.*
 
@@ -55,6 +56,7 @@ abstract class RemapSourcesJarTaskImpl @Inject constructor(provider: MinecraftCo
         }
 
         JarOutputStream(target.toFile().outputStream()).use { zos ->
+            zos.setLevel(Deflater.NO_COMPRESSION)
             output.walk().forEach { file ->
                 val name = output.relativize(file).toString().replace('\\', '/')
                 zos.putNextEntry(JarEntry(name))

--- a/src/minecraft/kotlin/xyz/wagyourtail/unimined/internal/minecraft/task/RemapSourcesJarTaskImpl.kt
+++ b/src/minecraft/kotlin/xyz/wagyourtail/unimined/internal/minecraft/task/RemapSourcesJarTaskImpl.kt
@@ -43,7 +43,8 @@ abstract class RemapSourcesJarTaskImpl @Inject constructor(provider: MinecraftCo
             fromNs,
             fromNs,
             toNs,
-            toNs
+            toNs,
+            specConfig = { standardOutput = temporaryDir.resolve("remap.log").outputStream() }
         )
 
         // copy non-java/kotlin files directly
@@ -62,10 +63,6 @@ abstract class RemapSourcesJarTaskImpl @Inject constructor(provider: MinecraftCo
                 it.inputStream().copyTo(o)
             }
         }
-    }
-
-    init {
-        project.unimined.wagYourMaven("snapshots")
     }
 
     companion object {

--- a/src/minecraft/kotlin/xyz/wagyourtail/unimined/internal/minecraft/task/RemapSourcesJarTaskImpl.kt
+++ b/src/minecraft/kotlin/xyz/wagyourtail/unimined/internal/minecraft/task/RemapSourcesJarTaskImpl.kt
@@ -1,0 +1,100 @@
+package xyz.wagyourtail.unimined.internal.minecraft.task
+
+import org.gradle.api.Project
+import org.gradle.api.tasks.SourceSet
+import org.gradle.jvm.tasks.Jar
+import xyz.wagyourtail.unimined.api.mapping.MappingNamespaceTree
+import xyz.wagyourtail.unimined.api.minecraft.MinecraftConfig
+import xyz.wagyourtail.unimined.api.unimined
+import xyz.wagyourtail.unimined.util.capitalized
+import java.nio.file.Path
+import java.util.jar.JarEntry
+import java.util.jar.JarOutputStream
+import javax.inject.Inject
+import kotlin.io.path.*
+
+abstract class RemapSourcesJarTaskImpl @Inject constructor(provider: MinecraftConfig): RemapJarTaskImpl(provider) {
+    @OptIn(ExperimentalPathApi::class)
+    override fun remapToInternal(
+        from: Path,
+        target: Path,
+        fromNs: MappingNamespaceTree.Namespace,
+        toNs: MappingNamespaceTree.Namespace,
+        classpathList: Array<Path>
+    ) {
+        val inputDir = temporaryDir.toPath().resolve("input").apply {
+            project.copy {
+                it.from(project.zipTree(inputFile.get().asFile))
+                it.into(this)
+            }
+        }
+
+        val outputDir = temporaryDir.toPath().resolve("output")
+
+        val remapper = provider.sourceProvider.sourceRemapper
+
+        fun Path.isSourceFile() = isRegularFile() && (name.endsWith(".java") || name.endsWith(".kt"))
+
+        remapper.remap(
+            inputDir.walk().filter { it.isSourceFile() }.associateWith {
+                outputDir.resolve(inputDir.relativize(it))
+            },
+            project.files(classpathList),
+            fromNs,
+            fromNs,
+            toNs,
+            toNs
+        )
+
+        // copy non-java/kotlin files directly
+        inputDir.walk().filter { it.isRegularFile() && !it.isSourceFile() }.forEach {
+            val relative = inputDir.relativize(it)
+            val output = outputDir.resolve(relative)
+            if (!output.exists()) {
+                it.copyTo(output.apply { parent.createDirectories() })
+            }
+        }
+
+        JarOutputStream(target.toFile().outputStream()).use { o ->
+            outputDir.walk().forEach {
+                val relative = outputDir.relativize(it)
+                o.putNextEntry(JarEntry(relative.toString().replace('\\', '/')))
+                it.inputStream().copyTo(o)
+            }
+        }
+    }
+
+    init {
+        project.unimined.wagYourMaven("snapshots")
+    }
+
+    companion object {
+        fun setup(sourceSet: SourceSet, project: Project) {
+            val sourcesJarTaskName = sourceSet.sourcesJarTaskName
+            val sourcesJarTask = project.tasks.findByName(sourcesJarTaskName)
+            if (sourcesJarTask == null) {
+                project.logger.warn("[Unimined/RemapSourcesJar] $sourcesJarTaskName task not found, not remapping sources")
+                return
+            }
+
+            if (sourcesJarTask !is Jar) {
+                project.logger.warn("[Unimined/RemapSourcesJar] $sourcesJarTaskName task is not a Jar task, not remapping it")
+                return
+            }
+
+            val remapTaskName = "remap${sourcesJarTaskName.capitalized()}"
+            val remapTask = project.tasks.register(remapTaskName, RemapSourcesJarTaskImpl::class.java, project.unimined.minecrafts[sourceSet])
+            remapTask.configure {
+                it.inputFile.set(sourcesJarTask.archiveFile)
+                it.dependsOn(sourcesJarTask)
+
+                it.description = "Remaps the sources jar for ${sourceSet.name}"
+                it.group = "unimined"
+
+                val oldClassifier = sourcesJarTask.archiveClassifier.get()
+                it.archiveClassifier.set(oldClassifier)
+                sourcesJarTask.archiveClassifier.set("dev-$oldClassifier")
+            }
+        }
+    }
+}

--- a/src/minecraft/kotlin/xyz/wagyourtail/unimined/internal/minecraft/task/RemapSourcesJarTaskImpl.kt
+++ b/src/minecraft/kotlin/xyz/wagyourtail/unimined/internal/minecraft/task/RemapSourcesJarTaskImpl.kt
@@ -10,9 +10,9 @@ import java.util.zip.Deflater
 import javax.inject.Inject
 import kotlin.io.path.*
 
-abstract class RemapSourcesJarTaskImpl @Inject constructor(provider: MinecraftConfig): RemapJarTaskImpl(provider) {
+abstract class RemapSourcesJarTaskImpl @Inject constructor(provider: MinecraftConfig): AbstractRemapJarTask(provider) {
     @OptIn(ExperimentalPathApi::class)
-    override fun remapToInternal(
+    override fun doRemap(
         from: Path,
         target: Path,
         fromNs: MappingNamespaceTree.Namespace,

--- a/src/source/kotlin/xyz/wagyourtail/unimined/internal/source/remapper/SourceRemapperImpl.kt
+++ b/src/source/kotlin/xyz/wagyourtail/unimined/internal/source/remapper/SourceRemapperImpl.kt
@@ -28,7 +28,6 @@ class SourceRemapperImpl(val project: Project, val provider: SourceProvider) : S
             project.dependencies.create(
                 if (dep is String && !dep.contains(":")) {
                     project.unimined.wagYourMaven("snapshots")
-                    project.repositories.mavenLocal()
                     "xyz.wagyourtail.unimined:source-remap:$dep"
                 } else {
                     dep
@@ -113,7 +112,7 @@ class SourceRemapperImpl(val project: Project, val provider: SourceProvider) : S
         specConfig: JavaExecSpec.() -> Unit
     ) {
         if (sourceRemapper.dependencies.isEmpty()) {
-            remapper("1.0.3-SNAPSHOT")
+            remapper("1.0.5-SNAPSHOT")
         }
 
         val mappingFile = tempDir.createDirectories().resolve("${provider.minecraft.sourceSet.name}-${source.name}-${target.name}.srg")

--- a/src/source/kotlin/xyz/wagyourtail/unimined/internal/source/remapper/SourceRemapperImpl.kt
+++ b/src/source/kotlin/xyz/wagyourtail/unimined/internal/source/remapper/SourceRemapperImpl.kt
@@ -1,7 +1,7 @@
 package xyz.wagyourtail.unimined.internal.source.remapper
 
 import org.gradle.api.Project
-import org.gradle.api.artifacts.Dependency
+import org.gradle.api.artifacts.ExternalModuleDependency
 import org.gradle.api.file.FileCollection
 import org.gradle.process.JavaExecSpec
 import xyz.wagyourtail.unimined.api.mapping.MappingNamespaceTree
@@ -23,18 +23,19 @@ class SourceRemapperImpl(val project: Project, val provider: SourceProvider) : S
 
     val sourceRemapper = project.configurations.maybeCreate("sourceRemapper".withSourceSet(provider.minecraft.sourceSet))
 
-    override fun remapper(dep: Any, action: Dependency.() -> Unit) {
+    override fun remapper(dep: Any, action: ExternalModuleDependency.() -> Unit) {
         sourceRemapper.dependencies.add(
             project.dependencies.create(
                 if (dep is String && !dep.contains(":")) {
                     project.unimined.wagYourMaven("snapshots")
+                    project.repositories.mavenLocal()
                     "xyz.wagyourtail.unimined:source-remap:$dep"
                 } else {
                     dep
                 }
             )
             .also {
-                action(it)
+                action(it as ExternalModuleDependency)
             }
         )
     }

--- a/testing/1.21-NeoForged-Fabric/build.gradle
+++ b/testing/1.21-NeoForged-Fabric/build.gradle
@@ -14,6 +14,8 @@ java {
     toolchain {
         languageVersion = JavaLanguageVersion.of(21)
     }
+
+    withSourcesJar()
 }
 
 // this is just here so we can test the outputs easier and clean between tests

--- a/testing/1.21-NeoForged-Fabric/gradle/wrapper/gradle-wrapper.properties
+++ b/testing/1.21-NeoForged-Fabric/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.10.2-bin.zip
 networkTimeout=10000
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/testing/1.21-NeoForged-Fabric/gradle/wrapper/gradle-wrapper.properties
+++ b/testing/1.21-NeoForged-Fabric/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,7 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.10.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.9-bin.zip
 networkTimeout=10000
+validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/testing/1.21-NeoForged-Fabric/gradlew
+++ b/testing/1.21-NeoForged-Fabric/gradlew
@@ -15,6 +15,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 
 ##############################################################################
 #
@@ -55,7 +57,7 @@
 #       Darwin, MinGW, and NonStop.
 #
 #   (3) This script is generated from the Groovy template
-#       https://github.com/gradle/gradle/blob/HEAD/subprojects/plugins/src/main/resources/org/gradle/api/internal/plugins/unixStartScript.txt
+#       https://github.com/gradle/gradle/blob/HEAD/platforms/jvm/plugins-application/src/main/resources/org/gradle/api/internal/plugins/unixStartScript.txt
 #       within the Gradle project.
 #
 #       You can find Gradle at https://github.com/gradle/gradle/.
@@ -83,10 +85,9 @@ done
 # This is normally unused
 # shellcheck disable=SC2034
 APP_BASE_NAME=${0##*/}
-APP_HOME=$( cd "${APP_HOME:-./}" && pwd -P ) || exit
-
-# Add default JVM options here. You can also use JAVA_OPTS and GRADLE_OPTS to pass JVM options to this script.
-DEFAULT_JVM_OPTS='"-Xmx64m" "-Xms64m"'
+# Discard cd standard output in case $CDPATH is set (https://github.com/gradle/gradle/issues/25036)
+APP_HOME=$( cd -P "${APP_HOME:-./}" > /dev/null && printf '%s
+' "$PWD" ) || exit
 
 # Use the maximum available, or set MAX_FD != -1 to use that value.
 MAX_FD=maximum
@@ -133,10 +134,13 @@ location of your Java installation."
     fi
 else
     JAVACMD=java
-    which java >/dev/null 2>&1 || die "ERROR: JAVA_HOME is not set and no 'java' command could be found in your PATH.
+    if ! command -v java >/dev/null 2>&1
+    then
+        die "ERROR: JAVA_HOME is not set and no 'java' command could be found in your PATH.
 
 Please set the JAVA_HOME variable in your environment to match the
 location of your Java installation."
+    fi
 fi
 
 # Increase the maximum file descriptors if we can.
@@ -144,7 +148,7 @@ if ! "$cygwin" && ! "$darwin" && ! "$nonstop" ; then
     case $MAX_FD in #(
       max*)
         # In POSIX sh, ulimit -H is undefined. That's why the result is checked to see if it worked.
-        # shellcheck disable=SC3045
+        # shellcheck disable=SC2039,SC3045
         MAX_FD=$( ulimit -H -n ) ||
             warn "Could not query maximum file descriptor limit"
     esac
@@ -152,7 +156,7 @@ if ! "$cygwin" && ! "$darwin" && ! "$nonstop" ; then
       '' | soft) :;; #(
       *)
         # In POSIX sh, ulimit -n is undefined. That's why the result is checked to see if it worked.
-        # shellcheck disable=SC3045
+        # shellcheck disable=SC2039,SC3045
         ulimit -n "$MAX_FD" ||
             warn "Could not set maximum file descriptor limit to $MAX_FD"
     esac
@@ -197,11 +201,15 @@ if "$cygwin" || "$msys" ; then
     done
 fi
 
-# Collect all arguments for the java command;
-#   * $DEFAULT_JVM_OPTS, $JAVA_OPTS, and $GRADLE_OPTS can contain fragments of
-#     shell script including quotes and variable substitutions, so put them in
-#     double quotes to make sure that they get re-expanded; and
-#   * put everything else in single quotes, so that it's not re-expanded.
+
+# Add default JVM options here. You can also use JAVA_OPTS and GRADLE_OPTS to pass JVM options to this script.
+DEFAULT_JVM_OPTS='"-Xmx64m" "-Xms64m"'
+
+# Collect all arguments for the java command:
+#   * DEFAULT_JVM_OPTS, JAVA_OPTS, JAVA_OPTS, and optsEnvironmentVar are not allowed to contain shell fragments,
+#     and any embedded shellness will be escaped.
+#   * For example: A user cannot expect ${Hostname} to be expanded, as it is an environment variable and will be
+#     treated as '${Hostname}' itself on the command line.
 
 set -- \
         "-Dorg.gradle.appname=$APP_BASE_NAME" \

--- a/testing/1.21-NeoForged-Fabric/gradlew.bat
+++ b/testing/1.21-NeoForged-Fabric/gradlew.bat
@@ -13,6 +13,8 @@
 @rem See the License for the specific language governing permissions and
 @rem limitations under the License.
 @rem
+@rem SPDX-License-Identifier: Apache-2.0
+@rem
 
 @if "%DEBUG%"=="" @echo off
 @rem ##########################################################################
@@ -43,11 +45,11 @@ set JAVA_EXE=java.exe
 %JAVA_EXE% -version >NUL 2>&1
 if %ERRORLEVEL% equ 0 goto execute
 
-echo.
-echo ERROR: JAVA_HOME is not set and no 'java' command could be found in your PATH.
-echo.
-echo Please set the JAVA_HOME variable in your environment to match the
-echo location of your Java installation.
+echo. 1>&2
+echo ERROR: JAVA_HOME is not set and no 'java' command could be found in your PATH. 1>&2
+echo. 1>&2
+echo Please set the JAVA_HOME variable in your environment to match the 1>&2
+echo location of your Java installation. 1>&2
 
 goto fail
 
@@ -57,11 +59,11 @@ set JAVA_EXE=%JAVA_HOME%/bin/java.exe
 
 if exist "%JAVA_EXE%" goto execute
 
-echo.
-echo ERROR: JAVA_HOME is set to an invalid directory: %JAVA_HOME%
-echo.
-echo Please set the JAVA_HOME variable in your environment to match the
-echo location of your Java installation.
+echo. 1>&2
+echo ERROR: JAVA_HOME is set to an invalid directory: %JAVA_HOME% 1>&2
+echo. 1>&2
+echo Please set the JAVA_HOME variable in your environment to match the 1>&2
+echo location of your Java installation. 1>&2
 
 goto fail
 


### PR DESCRIPTION
adds a function `MinecraftConfig.remapSources` just like `remap`, along with supporting infrastructure to remap said sources (`RemapSourcesJarTaskImpl`)

tests in `1.21-NeoForged-Fabric`

