### PR TITLE
fix legacy fabric maven

### DIFF
--- a/src/api/kotlin/xyz/wagyourtail/unimined/api/minecraft/patch/fabric/FabricLikeApiExtension.kt
+++ b/src/api/kotlin/xyz/wagyourtail/unimined/api/minecraft/patch/fabric/FabricLikeApiExtension.kt
@@ -114,7 +114,7 @@ open class FabricLikeApiExtension(val project: Project) {
         },
         "legacyFabric" to object : APILocations(project) {
             override fun getUrl(version: String): String {
-                return "https://repo.legacyfabric.net/repository/legacyfabric/net/legacyfabric/legacy-fabric-api/legacy-fabric-api/$version/legacy-fabric-api-$version.pom"
+                return "https://maven.legacyfabric.net/net/legacyfabric/legacy-fabric-api/legacy-fabric-api/$version/legacy-fabric-api-$version.pom"
             }
 
             override fun full(version: String): String {

--- a/src/api/kotlin/xyz/wagyourtail/unimined/util/Utils.kt
+++ b/src/api/kotlin/xyz/wagyourtail/unimined/util/Utils.kt
@@ -15,7 +15,6 @@ import org.gradle.api.artifacts.component.ModuleComponentIdentifier
 import org.gradle.api.file.FileCollection
 import org.gradle.api.tasks.SourceSet
 import org.gradle.api.tasks.SourceSetContainer
-import org.gradle.configurationcache.extensions.capitalized
 import xyz.wagyourtail.unimined.api.unimined
 import java.io.File
 import java.io.IOException

--- a/src/main/kotlin/xyz/wagyourtail/unimined/UniminedExtensionImpl.kt
+++ b/src/main/kotlin/xyz/wagyourtail/unimined/UniminedExtensionImpl.kt
@@ -3,13 +3,13 @@ package xyz.wagyourtail.unimined
 import org.gradle.api.Project
 import org.gradle.api.artifacts.repositories.MavenArtifactRepository
 import org.gradle.api.tasks.SourceSet
-import org.gradle.configurationcache.extensions.capitalized
 import xyz.wagyourtail.unimined.api.UniminedExtension
 import xyz.wagyourtail.unimined.api.source.task.MigrateMappingsTask
 import xyz.wagyourtail.unimined.api.minecraft.MinecraftConfig
 import xyz.wagyourtail.unimined.internal.mapping.task.MigrateMappingsTaskImpl
 import xyz.wagyourtail.unimined.internal.minecraft.MinecraftProvider
 import xyz.wagyourtail.unimined.internal.minecraft.patch.reindev.ReIndevProvider
+import xyz.wagyourtail.unimined.util.capitalized
 import xyz.wagyourtail.unimined.util.defaultedMapOf
 import xyz.wagyourtail.unimined.util.withSourceSet
 import java.net.URI
@@ -140,7 +140,7 @@ open class UniminedExtensionImpl(project: Project) : UniminedExtension(project) 
     val legacyFabricMaven by lazy {
         project.repositories.maven {
             it.name = "legacyFabric"
-            it.url = URI.create("https://repo.legacyfabric.net/repository/legacyfabric")
+            it.url = URI.create("https://maven.legacyfabric.net")
         }
     }
     override fun legacyFabricMaven() {


### PR DESCRIPTION
uses https://maven.legacyfabric.net which should redirect correctly if they change ~~again~~ in the future

also removes usages of `org.gradle.configurationcache.extensions.capitalized` in favor of the one in `Utils`