### PR TITLE
Fix RemapJarTaskImpl waiting indefinitely for TR to finish

### DIFF
--- a/src/minecraft/kotlin/xyz/wagyourtail/unimined/internal/minecraft/task/RemapJarTaskImpl.kt
+++ b/src/minecraft/kotlin/xyz/wagyourtail/unimined/internal/minecraft/task/RemapJarTaskImpl.kt
@@ -82,12 +82,12 @@ abstract class RemapJarTaskImpl @Inject constructor(provider: MinecraftConfig):
                 target.deleteIfExists()
                 throw e
             }
-            remapper.finish()
-            target.openZipFileSystem(mapOf("mutable" to true)).use {
-                betterMixinExtension.insertExtra(tag, it)
-            }
-            project.logger.info("[Unimined/RemapJar ${path}] remapped $fromNs -> $toNs (end time: ${System.currentTimeMillis()})")
         }.join()
+        remapper.finish()
+        target.openZipFileSystem(mapOf("mutable" to true)).use {
+            betterMixinExtension.insertExtra(tag, it)
+        }
+        project.logger.info("[Unimined/RemapJar ${path}] remapped $fromNs -> $toNs (end time: ${System.currentTimeMillis()})")
     }
 
 }


### PR DESCRIPTION
Previously, the `TinyRemapper#finish` call was invoked within the `thenRun` callback, but that is running on a TR-provided thread. This caused `finish` to just time out instead of returning quickly, which led to ridiculously long `remapJar` running time with no progress being made for most of the time.

The fix is to run this logic on the main thread instead.