### PR TITLE
don't add remapSourcesJar by default

### DIFF
--- a/src/api/kotlin/xyz/wagyourtail/unimined/api/minecraft/MinecraftConfig.kt
+++ b/src/api/kotlin/xyz/wagyourtail/unimined/api/minecraft/MinecraftConfig.kt
@@ -20,7 +20,6 @@ import xyz.wagyourtail.unimined.api.minecraft.resolver.MinecraftData
 import xyz.wagyourtail.unimined.api.mod.ModsConfig
 import xyz.wagyourtail.unimined.api.runs.RunsConfig
 import xyz.wagyourtail.unimined.api.source.SourceConfig
-import xyz.wagyourtail.unimined.api.minecraft.task.AbstractRemapJarTask
 import xyz.wagyourtail.unimined.api.minecraft.task.RemapJarTask
 import xyz.wagyourtail.unimined.api.minecraft.task.RemapSourcesJarTask
 import xyz.wagyourtail.unimined.api.unimined
@@ -94,6 +93,11 @@ abstract class MinecraftConfig(val project: Project, val sourceSet: SourceSet) :
      * should unimined add the default "remapJar" task to this sourceSet?
      */
     var defaultRemapJar: Boolean by FinalizeOnRead(true)
+
+    /**
+     * should unimined add the default "remapSourcesJar" task to this sourceSet?
+     */
+    var defaultRemapSourcesJar: Boolean by FinalizeOnRead(false)
 
     /**
      * if the jar task for defaultRemapJar doesn't exist, should unimined create it?

--- a/src/minecraft/kotlin/xyz/wagyourtail/unimined/internal/minecraft/MinecraftProvider.kt
+++ b/src/minecraft/kotlin/xyz/wagyourtail/unimined/internal/minecraft/MinecraftProvider.kt
@@ -450,20 +450,6 @@ open class MinecraftProvider(project: Project, sourceSet: SourceSet) : Minecraft
         }
     }
 
-    private fun applyDefaultRemapJars() {
-        applyDefaultRemapJar<RemapJarTaskImpl>("jar", ::remap) {
-            from(sourceSet.output)
-            archiveClassifier.set(sourceSet.name)
-            from(combinedWithList.map { it.second.output })
-        }
-
-        applyDefaultRemapJar<RemapSourcesJarTaskImpl>("sourcesJar", ::remapSources) {
-            from(sourceSet.allSource)
-            archiveClassifier.set("${sourceSet.name}-sources")
-            from(combinedWithList.map { it.second.allSource })
-        }
-    }
-
     private inline fun <reified T> applyDefaultRemapJar(
         inputTaskName: String,
         remappingFunction: (Task, JarInterface<AbstractRemapJarTask>.() -> Unit) -> Unit,
@@ -611,7 +597,19 @@ open class MinecraftProvider(project: Project, sourceSet: SourceSet) : Minecraft
         if (mcPatcher.addVanillaLibraries) addLibraries(minecraftData.metadata.libraries)
 
         if (defaultRemapJar) {
-            applyDefaultRemapJars()
+            applyDefaultRemapJar<RemapJarTaskImpl>("jar", ::remap) {
+                from(sourceSet.output)
+                archiveClassifier.set(sourceSet.name)
+                from(combinedWithList.map { it.second.output })
+            }
+        }
+
+        if (defaultRemapSourcesJar) {
+            applyDefaultRemapJar<RemapSourcesJarTaskImpl>("sourcesJar", ::remapSources) {
+                from(sourceSet.allSource)
+                archiveClassifier.set("${sourceSet.name}-sources")
+                from(combinedWithList.map { it.second.allSource })
+            }
         }
 
         // apply minecraft patcher changes


### PR DESCRIPTION
can be re-enabled with the `MinecraftConfig.defaultRemapSourcesJar` flag

should hopefully prevents stuff like https://github.com/unimined/unimined/issues/113 from happening by default