### PR TITLE
Only run mapping exports when export target does not exist

### DIFF
--- a/src/mapping/kotlin/xyz/wagyourtail/unimined/internal/mapping/MappingsProvider.kt
+++ b/src/mapping/kotlin/xyz/wagyourtail/unimined/internal/mapping/MappingsProvider.kt
@@ -624,8 +624,10 @@ class MappingsProvider(project: Project, minecraft: MinecraftConfig, val mapping
 
     public fun mappingCacheFile(): Path =
         (if (hasStubs) minecraft.localCache else project.unimined.getGlobalCache())
-            .resolve("mappings").resolve("${mappingKey}-${side}-${combinedNames}.tiny")
+            .resolve("mappings").resolve("${exportKey()}.tiny")
 
+    public fun exportKey(): String =
+        "${mappingKey}-${side}-${combinedNames}"
 
     override val combinedNames: String by lazy {
         if (!freeze) freeze = true

--- a/src/minecraft/kotlin/xyz/wagyourtail/unimined/internal/minecraft/patch/fabric/FabricLikeMinecraftTransformer.kt
+++ b/src/minecraft/kotlin/xyz/wagyourtail/unimined/internal/minecraft/patch/fabric/FabricLikeMinecraftTransformer.kt
@@ -105,7 +105,7 @@ abstract class FabricLikeMinecraftTransformer(
             .createDirectories()
             .resolve("intermediary2named-${provider.mappings.exportKey()}.jar")
             .apply {
-                if(!exists()) {
+                if(!exists() || project.unimined.forceReload) {
                     val export = ExportMappingsTaskImpl.ExportImpl(provider.mappings).apply {
                         location = toFile()
                         type = ExportMappingsTask.MappingExportTypes.TINY_V2

--- a/src/minecraft/kotlin/xyz/wagyourtail/unimined/internal/minecraft/patch/fabric/FabricLikeMinecraftTransformer.kt
+++ b/src/minecraft/kotlin/xyz/wagyourtail/unimined/internal/minecraft/patch/fabric/FabricLikeMinecraftTransformer.kt
@@ -103,17 +103,19 @@ abstract class FabricLikeMinecraftTransformer(
         provider.localCache
             .resolve("mappings")
             .createDirectories()
-            .resolve("intermediary2named.jar")
+            .resolve("intermediary2named-${provider.mappings.exportKey()}.jar")
             .apply {
-                val export = ExportMappingsTaskImpl.ExportImpl(provider.mappings).apply {
-                    location = toFile()
-                    type = ExportMappingsTask.MappingExportTypes.TINY_V2
-                    sourceNamespace = prodNamespace
-                    targetNamespace = setOf(provider.mappings.devNamespace)
-                    renameNs[provider.mappings.devNamespace] = "named"
+                if(!exists()) {
+                    val export = ExportMappingsTaskImpl.ExportImpl(provider.mappings).apply {
+                        location = toFile()
+                        type = ExportMappingsTask.MappingExportTypes.TINY_V2
+                        sourceNamespace = prodNamespace
+                        targetNamespace = setOf(provider.mappings.devNamespace)
+                        renameNs[provider.mappings.devNamespace] = "named"
+                    }
+                    export.validate()
+                    export.exportFunc(provider.mappings.mappingTree)
                 }
-                export.validate()
-                export.exportFunc(provider.mappings.mappingTree)
             }
     })
 

--- a/src/minecraft/kotlin/xyz/wagyourtail/unimined/internal/minecraft/patch/forge/ForgeLikeMinecraftTransformer.kt
+++ b/src/minecraft/kotlin/xyz/wagyourtail/unimined/internal/minecraft/patch/forge/ForgeLikeMinecraftTransformer.kt
@@ -202,7 +202,7 @@ abstract class ForgeLikeMinecraftTransformer(
     @set:ApiStatus.Experimental
     var srgToMCPAsSRG: Path by FinalizeOnRead(LazyMutable {
         provider.localCache.resolve("mappings").createDirectories().resolve(provider.mappings.combinedNames).resolve("srg2mcp.srg").apply {
-            if (!exists()) {
+            if (!exists() || project.unimined.forceReload) {
                 val export = ExportMappingsTaskImpl.ExportImpl(provider.mappings).apply {
                     location = toFile()
                     type = ExportMappingsTask.MappingExportTypes.SRG
@@ -219,7 +219,7 @@ abstract class ForgeLikeMinecraftTransformer(
     @set:ApiStatus.Experimental
     var srgToMCPAsMCP: Path by FinalizeOnRead(LazyMutable {
         provider.localCache.resolve("mappings").createDirectories().resolve(provider.mappings.combinedNames).resolve("srg2mcp.jar").apply {
-            if (!exists()) {
+            if (!exists() || project.unimined.forceReload) {
                 val export = ExportMappingsTaskImpl.ExportImpl(provider.mappings).apply {
                     location = toFile()
                     type = ExportMappingsTask.MappingExportTypes.MCP

--- a/src/minecraft/kotlin/xyz/wagyourtail/unimined/internal/minecraft/patch/forge/ForgeLikeMinecraftTransformer.kt
+++ b/src/minecraft/kotlin/xyz/wagyourtail/unimined/internal/minecraft/patch/forge/ForgeLikeMinecraftTransformer.kt
@@ -35,6 +35,7 @@ import java.io.File
 import java.io.InputStreamReader
 import java.nio.file.Path
 import kotlin.io.path.createDirectories
+import kotlin.io.path.exists
 
 abstract class ForgeLikeMinecraftTransformer(
     project: Project,
@@ -201,14 +202,16 @@ abstract class ForgeLikeMinecraftTransformer(
     @set:ApiStatus.Experimental
     var srgToMCPAsSRG: Path by FinalizeOnRead(LazyMutable {
         provider.localCache.resolve("mappings").createDirectories().resolve(provider.mappings.combinedNames).resolve("srg2mcp.srg").apply {
-            val export = ExportMappingsTaskImpl.ExportImpl(provider.mappings).apply {
-                location = toFile()
-                type = ExportMappingsTask.MappingExportTypes.SRG
-                sourceNamespace = provider.mappings.getNamespace("searge")
-                targetNamespace = setOf(provider.mappings.devNamespace)
+            if (!exists()) {
+                val export = ExportMappingsTaskImpl.ExportImpl(provider.mappings).apply {
+                    location = toFile()
+                    type = ExportMappingsTask.MappingExportTypes.SRG
+                    sourceNamespace = provider.mappings.getNamespace("searge")
+                    targetNamespace = setOf(provider.mappings.devNamespace)
+                }
+                export.validate()
+                export.exportFunc(provider.mappings.mappingTree)
             }
-            export.validate()
-            export.exportFunc(provider.mappings.mappingTree)
         }
     })
 
@@ -216,16 +219,18 @@ abstract class ForgeLikeMinecraftTransformer(
     @set:ApiStatus.Experimental
     var srgToMCPAsMCP: Path by FinalizeOnRead(LazyMutable {
         provider.localCache.resolve("mappings").createDirectories().resolve(provider.mappings.combinedNames).resolve("srg2mcp.jar").apply {
-            val export = ExportMappingsTaskImpl.ExportImpl(provider.mappings).apply {
-                location = toFile()
-                type = ExportMappingsTask.MappingExportTypes.MCP
-                sourceNamespace = provider.mappings.getNamespace("searge")
-                skipComments = true // the reader forge uses now is too dumb...
-                targetNamespace = setOf(provider.mappings.devNamespace)
-                envType = provider.side
+            if (!exists()) {
+                val export = ExportMappingsTaskImpl.ExportImpl(provider.mappings).apply {
+                    location = toFile()
+                    type = ExportMappingsTask.MappingExportTypes.MCP
+                    sourceNamespace = provider.mappings.getNamespace("searge")
+                    skipComments = true // the reader forge uses now is too dumb...
+                    targetNamespace = setOf(provider.mappings.devNamespace)
+                    envType = provider.side
+                }
+                export.validate()
+                export.exportFunc(provider.mappings.mappingTree)
             }
-            export.validate()
-            export.exportFunc(provider.mappings.mappingTree)
         }
     })
 


### PR DESCRIPTION
The goal of this change is to improve configuration (i.e. project reload) times by avoiding re-exporting the same mappings many times. To do this the export file is modified to include a key in its name, which allows skipping the export if the file already exists.

Not 100% sure if this is the correct way to go about doing that.