### PR TITLE
Fix NPE during configuration

### DIFF
--- a/src/minecraft/kotlin/xyz/wagyourtail/unimined/internal/minecraft/MinecraftProvider.kt
+++ b/src/minecraft/kotlin/xyz/wagyourtail/unimined/internal/minecraft/MinecraftProvider.kt
@@ -482,16 +482,12 @@ open class MinecraftProvider(project: Project, sourceSet: SourceSet) : Minecraft
             archiveClassifier.set(if(!oldClassifier.isNullOrEmpty()) "$oldClassifier-dev" else "dev")
         }
 
-        var remapTask: JarInterface<AbstractRemapJarTask>? = null
-
         remappingFunction(inputTask) {
-            remapTask = this
             group = "unimined"
             description = "Remaps $inputTask's output jar"
             asJar.archiveClassifier.set(oldClassifier)
+            project.tasks.getByName("build").dependsOn(this)
         }
-
-        project.tasks.getByName("build").dependsOn(remapTask)
     }
 
     fun applyRunConfigs() {


### PR DESCRIPTION
I kept running into an NPE from the `dependsOn` call here, apparently `remapTask` was still null when it's called. This fix seems to work locally...