### PR TITLE
Fix flatDir mod remaps

### DIFF
--- a/src/main/kotlin/xyz/wagyourtail/unimined/UniminedExtensionImpl.kt
+++ b/src/main/kotlin/xyz/wagyourtail/unimined/UniminedExtensionImpl.kt
@@ -84,7 +84,7 @@ open class UniminedExtensionImpl(project: Project) : UniminedExtension(project) 
         it.name = "modsRemap"
         it.dir(getLocalCache().resolve("modTransform").toFile())
         it.content {
-            it.includeGroupByRegex("remapped_.+")
+            it.includeGroupByRegex("remapped_.*")
         }
     }
 


### PR DESCRIPTION
I noticed that when using a `flatDir` in order to remap local dependencies/mods, the remapping repository is not searched.
This fixes this (by also allowing empty groups).