### PR TITLE
Add support for remapping wildcard mixin method targets with a descriptor

### DIFF
--- a/src/mapping/kotlin/xyz/wagyourtail/unimined/internal/mapping/extension/mixin/refmap/annotations/method/AbstractMethodAnnotationVisitor.kt
+++ b/src/mapping/kotlin/xyz/wagyourtail/unimined/internal/mapping/extension/mixin/refmap/annotations/method/AbstractMethodAnnotationVisitor.kt
@@ -125,6 +125,20 @@ abstract class AbstractMethodAnnotationVisitor(
                         }
 
                         if (target.isPresent) continue@outer
+                        else if (targetName == "*") {
+                            // The descriptor classnames may still be possible to remap, even though a wildcard method
+                            // name is provided
+                            val mappedDesc = mapper.asTrRemapper().mapMethodDesc(targetDesc)
+                            if (mappedDesc != targetDesc) {
+                                val mappedClass = resolver.resolveClass(targetClass)
+                                    .map { mapper.mapName(it) }
+                                    .orElse(targetClass)
+                                val mappedPrefix = if (targetClasses.size > 1) "L$mappedClass;*" else "*"
+                                refmap.addProperty(targetMethod, "$mappedPrefix$mappedDesc")
+                                noRefmapAcceptor("$mappedPrefix$mappedDesc")
+                                continue@outer
+                            }
+                        }
                     }
                 }
                 logger.warn(


### PR DESCRIPTION
This enables the following type of injector to be statically remapped:

```java
    // original code
    @Inject(method = {"*()Lnet/minecraft/client/renderer/ShaderInstance;"}, at = @At("RETURN"), cancellable = true)
    // statically remapped version
    @Inject(method = {"*()Lnet/minecraft/class_5944;"}, at = @At("RETURN"), cancellable = true)
```