### PR TITLE
[1.4.x] Upgrades, People! Upgrades!

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,10 +19,11 @@
 *.tar.gz
 *.rar
 
-build
-.gradle
+build/
+.gradle/
 !gradle/wrapper/gradle-wrapper.jar
-.idea
+.idea/
+.kotlin/
 
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*
@@ -34,5 +35,6 @@ testing/**/build
 testing/**/.idea
 testing/**/run
 
+# Generated Docs
 Writerside/v.list
 docs/

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,6 +1,12 @@
+import org.eclipse.jgit.api.Git
 import org.gradle.api.tasks.testing.logging.TestLogEvent
-import java.io.ByteArrayOutputStream
 import java.io.File
+
+buildscript {
+	dependencies {
+		classpath(libs.jgit)
+	}
+}
 
 plugins {
     kotlin("jvm") version libs.versions.kotlin.get()
@@ -144,15 +150,10 @@ tasks.jar {
     manifest {
         attributes(
             "Implementation-Version" to if (project.hasProperty("version_snapshot")) {
-                val stdout = ByteArrayOutputStream()
-                exec {
-                    commandLine("git", "rev-parse", "--short", "HEAD")
-                    standardOutput = stdout
-                }.assertNormalExitValue()
                 buildString {
                     append(project.version.toString().removeSuffix("-SNAPSHOT"))
                     append("-")
-                    append(stdout.toString().trim())
+                    append(Git.open(rootDir).repository.resolve("HEAD").abbreviate(7).name().trim())
                     append("-SNAPSHOT")
                 }
             } else project.version

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -186,27 +186,32 @@ tasks.test {
     }
 }
 
-tasks.dokkaHtml {
-    outputDirectory.set(projectDir.resolve("docs/api-docs/"))
-    dokkaSourceSets {
-        named("main") {
-            suppress = true
-        }
-        named("api") {
-            suppress = false
-        }
-    }
-    doFirst {
-        file("Writerside/v.list").writeText(
-            """
+tasks.dokkaGenerate {
+	doFirst {
+		file("Writerside/v.list").writeText(
+			"""
                 <?xml version="1.0" encoding="UTF-8"?>
                 <!DOCTYPE vars SYSTEM "https://resources.jetbrains.com/writerside/1.0/vars.dtd">
                 <vars>
                     <var name="version" value="${project.version}"/>
                 </vars>
             """.trimIndent()
-        )
-    }
+		)
+	}
+}
+
+dokka {
+	moduleName.set(project.displayName)
+	dokkaSourceSets.main {
+		suppress = true
+	}
+	dokkaSourceSets.named("api") {
+		suppress = false
+	}
+
+	dokkaPublications.html {
+		outputDirectory.set(projectDir.resolve("docs/api-docs/"))
+	}
 }
 
 gradlePlugin {

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,6 +3,9 @@ kotlin.code.style=official
 org.gradle.jvmargs=-Xmx1G
 org.gradle.parallel=true
 
+org.jetbrains.dokka.experimental.gradle.pluginMode=V2Enabled
+org.jetbrains.dokka.experimental.gradle.pluginMode.noWarn=true
+
 maven_group=xyz.wagyourtail.unimined
 archives_base_name=unimined
 version=1.4.2

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,12 +1,15 @@
 [versions]
 java = "8"
-kotlin = "2.1.10"
-jb-annotations = "24.1.0"
+# Kotlin 2.2.0 is only supported by Gradle 9+. Gradle 9 removes support for Java 8.
+kotlin = "2.1.20"
+dokka = "2.0.0"
 
-guava = "33.4.0-jre"
-gson = "2.12.1"
+jb-annotations = "26.0.2-1"
 
-asm = "9.7.1"
+guava = "33.4.8-jre"
+gson = "2.13.1"
+
+asm = "9.8"
 
 tiny-remapper = "0.8.7"
 unimined-mapping-library = "1.2.1"
@@ -14,21 +17,21 @@ unimined-mapping-library = "1.2.1"
 binarypatcher = "1.1.1"
 jbsdiff = "1.0"
 
-commons-io = "2.18.0"
-commons-compress = "1.27.1"
+commons-io = "2.20.0"
+commons-compress = "1.28.0"
 
 access-widener = "2.1.0"
 
-jgit = "5.13.2.202306221912-r"
+# JGit 5.x is the last version that supports Java 8.
+jgit = "5.13.3.202401111512-r"
 
 keyring = "1.0.2"
-minecraftauth = "4.1.1"
+minecraftauth = "4.1.2"
 
 junit = "5.12.0"
 
-dokka = "2.0.0"
-
 [libraries]
+
 jb-annotations = { module = "org.jetbrains:annotations", version.ref = "jb-annotations" }
 guava = { module = "com.google.guava:guava", version.ref = "guava" }
 gson = { module = "com.google.code.gson:gson", version.ref = "gson" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -11,7 +11,7 @@ gson = "2.13.1"
 
 asm = "9.8"
 
-tiny-remapper = "0.8.7"
+tiny-remapper = "0.11.1"
 unimined-mapping-library = "1.2.1"
 
 binarypatcher = "1.1.1"

--- a/src/api/kotlin/xyz/wagyourtail/unimined/api/minecraft/patch/bukkit/CraftbukkitPatcher.kt
+++ b/src/api/kotlin/xyz/wagyourtail/unimined/api/minecraft/patch/bukkit/CraftbukkitPatcher.kt
@@ -13,6 +13,6 @@ interface CraftbukkitPatcher : MinecraftPatcher {
         this.loader = version
     }
 
-    var classPathPluginLoader: Configuration?
+    var classPathPluginLoader: Configuration
     fun agentVersion(vers: String)
 }

--- a/src/api/kotlin/xyz/wagyourtail/unimined/api/minecraft/patch/bukkit/PaperPatcher.kt
+++ b/src/api/kotlin/xyz/wagyourtail/unimined/api/minecraft/patch/bukkit/PaperPatcher.kt
@@ -14,8 +14,11 @@ interface PaperPatcher : CraftbukkitPatcher {
         this.build = build
     }
 
-    override fun loader(build: String) {
-        this.build = build.toInt()
+	/**
+	 * [version] build number (must be an integer)
+	 */
+    override fun loader(version: String) {
+        this.build = version.toInt()
     }
 
     @get:ApiStatus.Internal

--- a/src/api/kotlin/xyz/wagyourtail/unimined/api/minecraft/task/RemapJarTask.kt
+++ b/src/api/kotlin/xyz/wagyourtail/unimined/api/minecraft/task/RemapJarTask.kt
@@ -15,7 +15,7 @@ interface RemapJarTask : JarInterface<AbstractRemapJarTask>, RemapOptions {
      */
     @get:Input
     @get:Optional
-    val remapATToLegacy: Property<Boolean?>
+    val remapATToLegacy: Property<Boolean>
 
     /**
      * Enable remapping of access wideners in the jar.
@@ -24,7 +24,7 @@ interface RemapJarTask : JarInterface<AbstractRemapJarTask>, RemapOptions {
      */
     @get:Input
     @get:Optional
-    val remapAccessWidener: Property<Boolean?>
+    val remapAccessWidener: Property<Boolean>
 
     /**
      * Enable remapping of access transformers in the jar.
@@ -33,7 +33,7 @@ interface RemapJarTask : JarInterface<AbstractRemapJarTask>, RemapOptions {
      */
     @get:Input
     @get:Optional
-    val remapAccessTransformer: Property<Boolean?>
+    val remapAccessTransformer: Property<Boolean>
 
     fun mixinRemap(action: MixinRemapOptions.() -> Unit)
 

--- a/src/main/kotlin/xyz/wagyourtail/unimined/UniminedExtensionImpl.kt
+++ b/src/main/kotlin/xyz/wagyourtail/unimined/UniminedExtensionImpl.kt
@@ -102,7 +102,7 @@ open class UniminedExtensionImpl(project: Project) : UniminedExtension(project) 
 
     override fun migrateMappings(sourceSet: SourceSet, action: MigrateMappingsTask.() -> Unit) {
 //        MigrateMappingsTaskImpl(project, sourceSet).apply(action)
-        project.tasks.create("migrateMappings".withSourceSet(sourceSet), MigrateMappingsTaskImpl::class.java, sourceSet).apply(action)
+        project.tasks.register("migrateMappings".withSourceSet(sourceSet), MigrateMappingsTaskImpl::class.java, sourceSet).orNull?.apply(action)
     }
 
     private fun getMinecraftDepNames(): Set<String> = minecrafts.values.map { (it as MinecraftProvider).minecraftDepName }.toSet()

--- a/src/mapping/kotlin/xyz/wagyourtail/unimined/internal/mapping/aw/AccessWidenerMerger.kt
+++ b/src/mapping/kotlin/xyz/wagyourtail/unimined/internal/mapping/aw/AccessWidenerMerger.kt
@@ -193,7 +193,6 @@ class AccessWidenerMerger(private val namespace: String): AccessWidenerVisitor {
             }
 
             AccessWidenerReader.AccessType.MUTABLE -> access.makeMutable()
-            else -> throw java.lang.UnsupportedOperationException("Unknown access type:$input")
         }
     }
 

--- a/src/mapping/kotlin/xyz/wagyourtail/unimined/internal/mapping/extension/MixinRemapExtension.kt
+++ b/src/mapping/kotlin/xyz/wagyourtail/unimined/internal/mapping/extension/MixinRemapExtension.kt
@@ -5,11 +5,10 @@ import net.fabricmc.tinyremapper.InputTag
 import net.fabricmc.tinyremapper.TinyRemapper
 import net.fabricmc.tinyremapper.api.TrClass
 import net.fabricmc.tinyremapper.api.TrEnvironment
-import net.fabricmc.tinyremapper.extension.mixin.common.Logger
 import net.fabricmc.tinyremapper.extension.mixin.common.data.Annotation
 import net.fabricmc.tinyremapper.extension.mixin.common.data.CommonData
 import net.fabricmc.tinyremapper.extension.mixin.common.data.Constant
-import org.gradle.api.logging.LogLevel
+import org.gradle.api.logging.Logger
 import org.jetbrains.annotations.ApiStatus
 import org.objectweb.asm.AnnotationVisitor
 import org.objectweb.asm.ClassVisitor
@@ -33,7 +32,7 @@ import java.util.concurrent.CompletableFuture
 import java.util.concurrent.ConcurrentLinkedDeque
 
 class MixinRemapExtension(
-    loggerLevel: LogLevel = LogLevel.WARN,
+    val logger: Logger,
     allowImplicitWildcards: Boolean = false,
 ) : PerInputTagExtension<MixinRemapExtension.MixinTarget>(), MixinRemapOptions {
 
@@ -50,13 +49,6 @@ class MixinRemapExtension(
     private var metadataReader = mutableListOf<(MixinRemapExtension) -> MixinMetadata>()
     private var modifyHardRemapper: (HardTargetRemappingClassVisitor) -> Unit = {}
     private var modifyRefmapBuilder: (RefmapBuilderClassVisitor) -> Unit = {}
-
-
-    val logger: Logger = Logger(
-        translateLogLevel(
-            loggerLevel
-        )
-    )
 
     var off by FinalizeOnRead(false)
     var noRefmap: Set<String> by FinalizeOnRead(setOf())
@@ -189,7 +181,7 @@ class MixinRemapExtension(
 
         override fun stateProcessor(environment: TrEnvironment) {
             extension.logger.info("[HardTarget] processing state for ${environment.mrjVersion}")
-            val data = CommonData(environment, extension.logger)
+            val data = CommonData(environment)
             try {
                 for (task in tasks[environment.mrjVersion]) {
                     task(data)
@@ -214,7 +206,7 @@ class MixinRemapExtension(
                     }
                     val target = JsonObject()
                     val visitor = RefmapBuilderClassVisitor(
-                        CommonData(cls.environment, extension.logger),
+                        CommonData(cls.environment),
                         cls.name,
                         target,
                         next,
@@ -241,7 +233,7 @@ class MixinRemapExtension(
                     if (!extension.off) {
                         val target = JsonObject()
                         val visitor = RefmapBuilderClassVisitor(
-                            CommonData(cls.environment, extension.logger),
+                            CommonData(cls.environment),
                             cls.name,
                             target,
                             next,
@@ -334,16 +326,5 @@ class MixinRemapExtension(
 
     companion object {
         fun dot(name: String): String = name.replace('/', '.')
-
-
-        fun translateLogLevel(loggerLevel: LogLevel) = when (loggerLevel) {
-            LogLevel.DEBUG -> Logger.Level.INFO
-            LogLevel.INFO -> Logger.Level.INFO
-            LogLevel.WARN -> Logger.Level.WARN
-            LogLevel.ERROR -> Logger.Level.ERROR
-            LogLevel.QUIET -> Logger.Level.ERROR
-            else -> Logger.Level.WARN
-        }
     }
-
 }

--- a/src/mapping/kotlin/xyz/wagyourtail/unimined/internal/mapping/extension/mixin/hard/HardTargetRemappingClassVisitor.kt
+++ b/src/mapping/kotlin/xyz/wagyourtail/unimined/internal/mapping/extension/mixin/hard/HardTargetRemappingClassVisitor.kt
@@ -1,9 +1,9 @@
 package xyz.wagyourtail.unimined.internal.mapping.extension.mixin.hard
 
-import net.fabricmc.tinyremapper.extension.mixin.common.Logger
 import net.fabricmc.tinyremapper.extension.mixin.common.data.CommonData
 import net.fabricmc.tinyremapper.extension.mixin.common.data.Constant
 import net.fabricmc.tinyremapper.extension.mixin.common.data.MxClass
+import org.gradle.api.logging.Logger
 import org.objectweb.asm.AnnotationVisitor
 import org.objectweb.asm.ClassVisitor
 import org.objectweb.asm.FieldVisitor
@@ -69,11 +69,11 @@ typealias FieldAnnotationVisitor = (
 ) -> AnnotationVisitor
 
 class HardTargetRemappingClassVisitor(
-    delegate: ClassVisitor?,
-    val mixinName: String,
-    val existingMappings: Map<String, String>,
-    val logger: Logger,
-    val onEnd: () -> Unit = {}
+	delegate: ClassVisitor?,
+	val mixinName: String,
+	val existingMappings: Map<String, String>,
+	val logger: Logger,
+	val onEnd: () -> Unit = {}
 ) : ClassVisitor(Constant.ASM_VERSION, delegate) {
 
     lateinit var mxClass: MxClass

--- a/src/minecraft/kotlin/xyz/wagyourtail/unimined/internal/minecraft/MinecraftProvider.kt
+++ b/src/minecraft/kotlin/xyz/wagyourtail/unimined/internal/minecraft/MinecraftProvider.kt
@@ -476,10 +476,10 @@ open class MinecraftProvider(project: Project, sourceSet: SourceSet) : Minecraft
         var inputTask = project.tasks.findByName(inputTaskName.withSourceSet(sourceSet))
         if (inputTask == null && createJarTask) {
             project.logger.info("[Unimined/Minecraft ${project.path}:${sourceSet.name}] Creating default $inputTaskName for $sourceSet")
-            inputTask = project.tasks.create(inputTaskName.withSourceSet(sourceSet), Jar::class.java) {
+            inputTask = project.tasks.register(inputTaskName.withSourceSet(sourceSet), Jar::class.java) {
                 it.group = "build"
                 defaultTaskConfiguration(it, true)
-            }
+            }.getOrNull()
         } else if (inputTask != null) {
             if (inputTask is Jar) {
                 inputTask.also {
@@ -491,7 +491,7 @@ open class MinecraftProvider(project: Project, sourceSet: SourceSet) : Minecraft
             }
         }
 
-        if (inputTask != null && inputTask is Jar) {
+        if (inputTask != null) {
             val classifier: String = inputTask.archiveClassifier.getOrElse("")
             inputTask.apply {
                 if (classifier.isNotEmpty()) {
@@ -526,8 +526,6 @@ open class MinecraftProvider(project: Project, sourceSet: SourceSet) : Minecraft
             EnvType.JOINED -> {
                 provideRunClientTask("client", project.file("run/client"))
                 provideRunServerTask("server", project.file("run/server"))
-            }
-            else -> {
             }
         }
     }

--- a/src/minecraft/kotlin/xyz/wagyourtail/unimined/internal/minecraft/MinecraftProvider.kt
+++ b/src/minecraft/kotlin/xyz/wagyourtail/unimined/internal/minecraft/MinecraftProvider.kt
@@ -1,3 +1,5 @@
+@file:Suppress("UNCHECKED_CAST")
+
 package xyz.wagyourtail.unimined.internal.minecraft
 
 import kotlinx.coroutines.runBlocking

--- a/src/minecraft/kotlin/xyz/wagyourtail/unimined/internal/minecraft/patch/AbstractMinecraftTransformer.kt
+++ b/src/minecraft/kotlin/xyz/wagyourtail/unimined/internal/minecraft/patch/AbstractMinecraftTransformer.kt
@@ -53,7 +53,8 @@ abstract class AbstractMinecraftTransformer protected constructor(
 
     open fun defaultProdNamespace() = provider.mappings.checkedNs("official")
 
-    override fun prodNamespace(namespace: String) {
+    @Suppress("UNCHECKED_CAST")
+	override fun prodNamespace(namespace: String) {
         val delegate = AbstractMinecraftTransformer::class.getField("prodNamespace")!!.getDelegate(this) as FinalizeOnRead<Namespace>
         delegate.setValueIntl(LazyMutable { provider.mappings.checkedNs(namespace) })
     }

--- a/src/minecraft/kotlin/xyz/wagyourtail/unimined/internal/minecraft/patch/bukkit/CraftbukkitMinecraftTransformer.kt
+++ b/src/minecraft/kotlin/xyz/wagyourtail/unimined/internal/minecraft/patch/bukkit/CraftbukkitMinecraftTransformer.kt
@@ -1,6 +1,7 @@
 package xyz.wagyourtail.unimined.internal.minecraft.patch.bukkit
 
 import org.gradle.api.Project
+import org.gradle.api.artifacts.Configuration
 import org.gradle.api.artifacts.ExternalDependency
 import org.w3c.dom.Element
 import xyz.wagyourtail.unimined.api.mapping.MappingsConfig
@@ -26,6 +27,7 @@ import xyz.wagyourtail.unimined.mapping.visitor.delegate.Delegator
 import xyz.wagyourtail.unimined.mapping.visitor.delegate.delegator
 import xyz.wagyourtail.unimined.util.*
 import java.io.File
+import java.nio.file.Path
 import kotlin.io.path.copyTo
 
 open class CraftbukkitMinecraftTransformer(
@@ -33,10 +35,13 @@ open class CraftbukkitMinecraftTransformer(
     provider: MinecraftProvider,
     providerName: String = "craftbukkit"
 ) : AbstractMinecraftTransformer(project, provider, providerName), CraftbukkitPatcher {
+	companion object {
+		const val CPL_GROUPS = "cpl.pluginGroups"
+	}
 
     override val supportedEnvs = setOf(EnvType.SERVER)
 
-    val cache by lazy {
+    val cache: Path by lazy {
         project.unimined.getLocalCache(provider.sourceSet).resolve("spigot")
     }
 
@@ -47,11 +52,11 @@ open class CraftbukkitMinecraftTransformer(
         provider.sourceSet.runtimeClasspath += this
     }
 
-    override var classPathPluginLoader = project.configurations.maybeCreate("classpathPluginLoader".withSourceSet(provider.sourceSet)).apply {
+    override var classPathPluginLoader: Configuration = project.configurations.maybeCreate("classpathPluginLoader".withSourceSet(provider.sourceSet)).apply {
         provider.minecraftLibraries.extendsFrom(this)
     }
 
-    val cplFile by lazy {
+    val cplFile: Path by lazy {
         classPathPluginLoader.resolve().first { it.extension == "jar" }.toPath()
     }
 
@@ -66,8 +71,6 @@ open class CraftbukkitMinecraftTransformer(
     }
 
     override fun defaultProdNamespace() = provider.mappings.checkedNs("spigotProd")
-
-    val CPL_GROUPS = "cpl.pluginGroups"
 
     override fun agentVersion(vers: String) {
         project.unimined.wagYourMaven("releases")
@@ -163,14 +166,13 @@ open class CraftbukkitMinecraftTransformer(
 
             insertInto.add {
                 it.delegator(object : Delegator() {
-                    val official = Namespace("official")
                     val spigotProd = Namespace("spigotProd")
 
                     override fun visitClass(
                         delegate: MappingVisitor,
                         names: Map<Namespace, InternalName>
                     ): ClassVisitor? {
-                        var spigotProdName = names[spigotProd]
+                        val spigotProdName = names[spigotProd]
                         if (executor.versionInfo.mappingsUrl == null) {
                             if (spigotProdName != null) {
                                 val newName = "net/minecraft/server/v${executor.minecraftVersion}/" + spigotProdName.value.substringAfterLast("/")
@@ -213,7 +215,7 @@ open class CraftbukkitMinecraftTransformer(
                 groups.remove(proj to sourceSet)
             }
         }
-        project.logger.info("[Unimined/FabricLike] Classpath groups: ${groups.map { it.key.toPath() + " -> " + it.value.joinToString(", ") { it.toPath() } }.joinToString("\n    ")}")
+        project.logger.info("[Unimined/FabricLike] Classpath groups: ${groups.map { entry -> entry.key.toPath() + " -> " + entry.value.joinToString(", ") { it.toPath() } }.joinToString("\n    ")}")
         groups.map { entry -> entry.value.flatMap { it.second.output }.joinToString(File.pathSeparator) { it.absolutePath } }.joinToString(
             File.pathSeparator.repeat(2))
     }

--- a/src/minecraft/kotlin/xyz/wagyourtail/unimined/internal/minecraft/patch/forge/fg2/FG2MinecraftTransformer.kt
+++ b/src/minecraft/kotlin/xyz/wagyourtail/unimined/internal/minecraft/patch/forge/fg2/FG2MinecraftTransformer.kt
@@ -36,7 +36,7 @@ open class FG2MinecraftTransformer(project: Project, val parent: ForgeLikeMinecr
             "net/neoforged/neoforge/registries/ObjectHolderRegistry"
         )
         parent.provider.minecraftRemapper.addExtension {
-            StringClassNameRemapExtension(project.gradle.startParameter.logLevel) {
+            StringClassNameRemapExtension(project.logger) {
 //            it.matches(Regex("^net/minecraftforge/.*"))
                 forgeHardcodedNames.contains(it)
             }

--- a/src/minecraft/kotlin/xyz/wagyourtail/unimined/internal/minecraft/patch/forge/fg3/FG3MinecraftTransformer.kt
+++ b/src/minecraft/kotlin/xyz/wagyourtail/unimined/internal/minecraft/patch/forge/fg3/FG3MinecraftTransformer.kt
@@ -69,7 +69,7 @@ open class FG3MinecraftTransformer(project: Project, val parent: ForgeLikeMinecr
             "net/neoforged/neoforge/registries/ObjectHolderRegistry"
         )
         parent.provider.minecraftRemapper.addExtension {
-            StringClassNameRemapExtension(project.gradle.startParameter.logLevel) {
+            StringClassNameRemapExtension(project.logger) {
 //            it.matches(Regex("^net/minecraftforge/.*"))
                 forgeHardcodedNames.contains(it)
             }

--- a/src/minecraft/kotlin/xyz/wagyourtail/unimined/internal/minecraft/patch/forge/fg3/FG3MinecraftTransformer.kt
+++ b/src/minecraft/kotlin/xyz/wagyourtail/unimined/internal/minecraft/patch/forge/fg3/FG3MinecraftTransformer.kt
@@ -542,7 +542,7 @@ open class FG3MinecraftTransformer(project: Project, val parent: ForgeLikeMinecr
             val stoutLevel = project.gradle.startParameter.logLevel
             val stdout = System.out
             if (stoutLevel > LogLevel.INFO) {
-                System.setOut(PrintStream(NullOutputStream.NULL_OUTPUT_STREAM))
+                System.setOut(PrintStream(NullOutputStream.INSTANCE))
             }
             project.logger.info("Running binpatcher with args: ${args.joinToString(" ")}")
             try {
@@ -568,7 +568,7 @@ open class FG3MinecraftTransformer(project: Project, val parent: ForgeLikeMinecr
         }
     }
 
-    val legacyClasspath by lazy {
+    val legacyClasspath: Path by lazy {
         val lcp = provider.localCache.createDirectories().resolve("legacy_classpath.txt")
         lcp.writeText(
             (provider.minecraftLibraries.files + provider.minecraftFileDev + clientExtra.resolve()).joinToString(

--- a/src/minecraft/kotlin/xyz/wagyourtail/unimined/internal/minecraft/patch/forge/fg3/StringClassNameRemapExtension.kt
+++ b/src/minecraft/kotlin/xyz/wagyourtail/unimined/internal/minecraft/patch/forge/fg3/StringClassNameRemapExtension.kt
@@ -2,19 +2,16 @@ package xyz.wagyourtail.unimined.internal.minecraft.patch.forge.fg3
 
 import net.fabricmc.tinyremapper.TinyRemapper
 import net.fabricmc.tinyremapper.api.TrClass
-import net.fabricmc.tinyremapper.extension.mixin.common.Logger
 import net.fabricmc.tinyremapper.extension.mixin.common.data.Constant
-import org.gradle.api.logging.LogLevel
+import org.gradle.api.logging.Logger
 import org.objectweb.asm.ClassVisitor
 import org.objectweb.asm.MethodVisitor
-import xyz.wagyourtail.unimined.internal.mapping.extension.MixinRemapExtension
 
 class StringClassNameRemapExtension(
-    loggerLevel: LogLevel = LogLevel.WARN,
+    val logger: Logger,
     val classFilter: (String) -> Boolean = { true }
 ) : TinyRemapper.Extension, TinyRemapper.ApplyVisitorProvider {
 
-    private val logger: Logger = Logger(MixinRemapExtension.translateLogLevel(loggerLevel))
     override fun attach(builder: TinyRemapper.Builder) {
         builder.extraPreApplyVisitor(this)
     }

--- a/src/minecraft/kotlin/xyz/wagyourtail/unimined/internal/minecraft/patch/forge/fg3/mcpconfig/MCPConfig.kt
+++ b/src/minecraft/kotlin/xyz/wagyourtail/unimined/internal/minecraft/patch/forge/fg3/mcpconfig/MCPConfig.kt
@@ -287,7 +287,7 @@ class MCPConfig(
                             }.executablePath.asFile.absolutePath
                         }
                     } else {
-                        if (JavaVersion.current() < (JavaVersion.toVersion(function.java_version) ?: JavaVersion.VERSION_1_8)) {
+                        if (JavaVersion.current() < (JavaVersion.toVersion(function.java_version ?: 8))) {
                             error("current java version ${JavaVersion.current()} is less than required java version ${function.java_version} to run ${function.version}")
                         }
                     }

--- a/src/minecraft/kotlin/xyz/wagyourtail/unimined/internal/minecraft/patch/jarmod/JarModAgentMinecraftTransformer.kt
+++ b/src/minecraft/kotlin/xyz/wagyourtail/unimined/internal/minecraft/patch/jarmod/JarModAgentMinecraftTransformer.kt
@@ -105,7 +105,11 @@ open class JarModAgentMinecraftTransformer(
             config.jvmArgs("-D${JMA_TRANSFORMERS}=${transforms.joinToString(File.pathSeparator)}")
         }
         // priority classpath
-        val priorityClasspath = provider.detectCombineWithSourceSets().map { it.second.output.classesDirs.toMutableSet().also {set-> it.second.output.resourcesDir.let { set.add(it) } } }.flatten()
+        val priorityClasspath = provider.detectCombineWithSourceSets().map { pair ->
+			pair.second.output.classesDirs.toMutableSet().also { set ->
+				pair.second.output.resourcesDir?.let { set.add(it) }
+			}
+		}.flatten()
         if (priorityClasspath.isNotEmpty()) {
             config.jvmArgs("-D${JMA_PRIORITY_CLASSPATH}=${priorityClasspath.joinToString(File.pathSeparator) { it.absolutePath }}")
         }
@@ -113,20 +117,20 @@ open class JarModAgentMinecraftTransformer(
         //TODO: add mods to priority classpath, and resolve their jma.transformers
     }
 
-    override fun beforeRemapJarTask(task: AbstractRemapJarTask, input: Path): Path {
-        if (task is RemapJarTask) {
-            task.mixinRemap {
+    override fun beforeRemapJarTask(remapJarTask: AbstractRemapJarTask, input: Path): Path {
+        if (remapJarTask is RemapJarTask) {
+            remapJarTask.mixinRemap {
                 enableJarModAgent()
             }
         }
 
         @Suppress("DEPRECATION")
-        return if (enableJarModAgent && compiletimeTransforms && transforms.isNotEmpty() && task is RemapJarTask) {
-            project.logger.lifecycle("[Unimined/JarModAgentTransformer] Running compile time transforms for ${task}...")
+        return if (enableJarModAgent && compiletimeTransforms && transforms.isNotEmpty() && remapJarTask is RemapJarTask) {
+            project.logger.lifecycle("[Unimined/JarModAgentTransformer] Running compile time transforms for ${remapJarTask}...")
             val output = getTempFilePath("${input.nameWithoutExtension}-jma", ".jar")
             Files.copy(input, output)
             try {
-                val classpath = (task as RemapJarTaskImpl).provider.sourceSet.runtimeClasspath.files.toMutableSet()
+                val classpath = (remapJarTask as RemapJarTaskImpl).provider.sourceSet.runtimeClasspath.files.toMutableSet()
 
                 val result = project.execOps.javaexec {
                     it.jvmArgs = listOf(
@@ -150,7 +154,7 @@ open class JarModAgentMinecraftTransformer(
             }
             output
         } else {
-            super.beforeRemapJarTask(task, input)
+            super.beforeRemapJarTask(remapJarTask, input)
         }
     }
 

--- a/src/minecraft/kotlin/xyz/wagyourtail/unimined/internal/minecraft/patch/liteloader/LiteLoaderMinecraftTransformer.kt
+++ b/src/minecraft/kotlin/xyz/wagyourtail/unimined/internal/minecraft/patch/liteloader/LiteLoaderMinecraftTransformer.kt
@@ -54,7 +54,7 @@ open class LiteLoaderMinecraftTransformer(
         val version = liteloader?.version ?: error("liteloader version not set")
 
         if (versions != null) {
-            provider.mods.modImplementation.dependencies.add(liteloader)
+            provider.mods.modImplementation.dependencies.add(liteloader!!)
 
             val versions = if (version.endsWith("SNAPSHOT")) {
                 val versions = versions!!["snapshots"].asJsonObject
@@ -76,7 +76,7 @@ open class LiteLoaderMinecraftTransformer(
 
             throw IllegalStateException("failed to find liteloader version: $version")
         } else {
-            jarModConfiguration.dependencies.add(liteloader)
+            jarModConfiguration.dependencies.add(liteloader!!)
         }
     }
 

--- a/src/minecraft/kotlin/xyz/wagyourtail/unimined/internal/minecraft/patch/rift/RiftMinecraftTransformer.kt
+++ b/src/minecraft/kotlin/xyz/wagyourtail/unimined/internal/minecraft/patch/rift/RiftMinecraftTransformer.kt
@@ -52,7 +52,7 @@ open class RiftMinecraftTransformer(
 
         if (rift == null) rift = project.dependencies.create("org.dimdev:rift:${provider.version}")
 
-        project.configurations.getByName("modImplementation".withSourceSet(provider.sourceSet)).dependencies.add(rift)
+        project.configurations.getByName("modImplementation".withSourceSet(provider.sourceSet)).dependencies.add(rift!!)
 
         super.apply()
     }

--- a/src/minecraft/kotlin/xyz/wagyourtail/unimined/internal/minecraft/task/RemapJarTaskImpl.kt
+++ b/src/minecraft/kotlin/xyz/wagyourtail/unimined/internal/minecraft/task/RemapJarTaskImpl.kt
@@ -28,7 +28,7 @@ abstract class RemapJarTaskImpl @Inject constructor(provider: MinecraftConfig):
     @get:Internal
     protected var mixinRemapOptions: MixinRemapOptions.() -> Unit by FinalizeOnRead {}
 
-
+	@Suppress("UNCHECKED_CAST")
     override fun mixinRemap(action: MixinRemapOptions.() -> Unit) {
         val delegate: FinalizeOnRead<MixinRemapOptions.() -> Unit> = RemapJarTaskImpl::class.getField("mixinRemapOptions")!!.getDelegate(this) as FinalizeOnRead<MixinRemapOptions.() -> Unit>
         val old = delegate.value as MixinRemapOptions.() -> Unit

--- a/src/minecraft/kotlin/xyz/wagyourtail/unimined/internal/minecraft/task/RemapJarTaskImpl.kt
+++ b/src/minecraft/kotlin/xyz/wagyourtail/unimined/internal/minecraft/task/RemapJarTaskImpl.kt
@@ -77,7 +77,7 @@ abstract class RemapJarTaskImpl @Inject constructor(provider: MinecraftConfig):
             remapperB.extension(KotlinRemapperClassloader.create(classpath).tinyRemapperExtension)
         }
         val betterMixinExtension = MixinRemapExtension(
-            project.gradle.startParameter.logLevel,
+            project.logger,
             allowImplicitWildcards
         )
         betterMixinExtension.enableBaseMixin()

--- a/src/mods/kotlin/xyz/wagyourtail/unimined/internal/mods/ModRemapProvider.kt
+++ b/src/mods/kotlin/xyz/wagyourtail/unimined/internal/mods/ModRemapProvider.kt
@@ -134,7 +134,7 @@ class ModRemapProvider(config: Set<Configuration>, val project: Project, val pro
             remapperB.extension(KotlinRemapperClassloader.create(classpath).tinyRemapperExtension)
         }
         val mixinExtension = MixinRemapExtension(
-                project.gradle.startParameter.logLevel,
+                project.logger,
                 allowImplicitWildcards = true
             )
         mixinExtension.enableBaseMixin()


### PR DESCRIPTION
This upgrades all of the libraries to their latest version with minimal breaking changes.

![Upgrades, people!](https://media.tenor.com/hxzwphaULpoAAAAM/upgrades-robots.gif)

Tiny Remapper removed the `Logger` class so I've made some potentially breaking changes to the RemapExtension classes to fix it. Instead of passing in the logger level and converting it, we just pass in the project's logger.

- Migrated to Dokka V2 and suppressed the related messages
- Fixed issues related to using Gradle 9.0.0, such as removed functions and warnings that were escalated to errors
- Did NOT upgrade Gradle wrapper to 9.0.0, because we're trying to maintain Java 1.8 compatibility