### PR TITLE
Fix modern versions of NeoForge failing to complete setup

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -173,6 +173,10 @@ dependencies {
     implementation("net.minecraftforge:binarypatcher:1.1.1") {
         exclude(mapOf("group" to "commons-io"))
     }
+
+    implementation("net.neoforged.installertools:binarypatcher:4.0.7") {
+        exclude(mapOf("group" to "commons-io"))
+    }
     implementation("commons-io:commons-io:2.16.1")
 
     // pack200 provided by apache commons-compress

--- a/src/minecraft/kotlin/xyz/wagyourtail/unimined/internal/minecraft/patch/forge/fg3/FG3MinecraftTransformer.kt
+++ b/src/minecraft/kotlin/xyz/wagyourtail/unimined/internal/minecraft/patch/forge/fg3/FG3MinecraftTransformer.kt
@@ -390,6 +390,9 @@ open class FG3MinecraftTransformer(project: Project, val parent: ForgeLikeMinecr
 
         if (!patchedMC.path.exists() || project.unimined.forceReload) {
             patchedMC.path.deleteIfExists()
+            val additionalArgs = listOf("--data", "--unpatched")
+            val isModernNeo = (SemVerUtils.matches(provider.version, ">1.21.10") && parent.providerName.equals("NeoForged", true))
+
             val args = (userdevCfg["binpatcher"].asJsonObject["args"].asJsonArray.map {
                 when (it.asString) {
                     "{clean}" -> inputMC.path.toString()
@@ -397,7 +400,7 @@ open class FG3MinecraftTransformer(project: Project, val parent: ForgeLikeMinecr
                     "{output}" -> patchedMC.path.toString()
                     else -> it.asString
                 }
-            } + listOf("--data", "--unpatched")).toTypedArray()
+            } + if (isModernNeo) listOf() else additionalArgs).toTypedArray()
             val stoutLevel = project.gradle.startParameter.logLevel
             val stdout = System.out
             if (stoutLevel > LogLevel.INFO) {
@@ -405,7 +408,11 @@ open class FG3MinecraftTransformer(project: Project, val parent: ForgeLikeMinecr
             }
             project.logger.info("Running binpatcher with args: ${args.joinToString(" ")}")
             try {
-                ConsoleTool.main(args)
+                if (isModernNeo) {
+                    net.neoforged.binarypatcher.ConsoleTool.main(args)
+                } else {
+                    ConsoleTool.main(args)
+                }
             } catch (e: Throwable) {
                 e.printStackTrace()
                 patchedMC.path.deleteIfExists()

--- a/src/minecraft/kotlin/xyz/wagyourtail/unimined/internal/minecraft/patch/forge/fg3/FG3MinecraftTransformer.kt
+++ b/src/minecraft/kotlin/xyz/wagyourtail/unimined/internal/minecraft/patch/forge/fg3/FG3MinecraftTransformer.kt
@@ -391,7 +391,7 @@ open class FG3MinecraftTransformer(project: Project, val parent: ForgeLikeMinecr
         if (!patchedMC.path.exists() || project.unimined.forceReload) {
             patchedMC.path.deleteIfExists()
             val additionalArgs = listOf("--data", "--unpatched")
-            val isModernNeo = (provider.minecraftData.mcVersionCompare("1.21.11", provider.version) == -1 && parent.providerName.equals("NeoForged", true))
+            val isModernNeo = (provider.minecraftData.mcVersionCompare("1.21.9", provider.version) == -1 && parent.providerName.equals("NeoForged", true))
 
             val args = (userdevCfg["binpatcher"].asJsonObject["args"].asJsonArray.map {
                 when (it.asString) {

--- a/src/minecraft/kotlin/xyz/wagyourtail/unimined/internal/minecraft/patch/forge/fg3/FG3MinecraftTransformer.kt
+++ b/src/minecraft/kotlin/xyz/wagyourtail/unimined/internal/minecraft/patch/forge/fg3/FG3MinecraftTransformer.kt
@@ -391,7 +391,7 @@ open class FG3MinecraftTransformer(project: Project, val parent: ForgeLikeMinecr
         if (!patchedMC.path.exists() || project.unimined.forceReload) {
             patchedMC.path.deleteIfExists()
             val additionalArgs = listOf("--data", "--unpatched")
-            val isModernNeo = (SemVerUtils.matches(provider.version, ">1.21.10") && parent.providerName.equals("NeoForged", true))
+            val isModernNeo = (provider.minecraftData.mcVersionCompare("1.21.11", provider.version) == -1 && parent.providerName.equals("NeoForged", true))
 
             val args = (userdevCfg["binpatcher"].asJsonObject["args"].asJsonArray.map {
                 when (it.asString) {


### PR DESCRIPTION
This PR fixes modern versions of NeoForge failing to set up in IDE.

This is done by using the NeoForge binary patcher for version 1.21.10 and above, instead of using the forge one.

I tested this in my own IDE and it worked without issues as far as I can tell.

This should fix #172 