### PR TITLE
Add support for 26.1 being completely unobfuscated

### DIFF
--- a/src/api/kotlin/xyz/wagyourtail/unimined/api/mapping/MappingsConfig.kt
+++ b/src/api/kotlin/xyz/wagyourtail/unimined/api/mapping/MappingsConfig.kt
@@ -35,6 +35,9 @@ abstract class MappingsConfig<T: MappingsConfig<T>>(val project: Project, val mi
     }) {
 
     private var innerDevNamespace: Namespace by FinalizeOnRead(LazyMutable {
+        if (minecraft.minecraftData.mcVersionCompare("1.21.11", minecraft.version) <= 0) {
+            return@LazyMutable Namespace("official")
+        }
         namespaces.entries.firstOrNull { it.value }?.key ?: error("No \"Named\" namespace found for devNamespace, if this is correct, set devNamespace explicitly")
     })
 

--- a/src/mapping/kotlin/xyz/wagyourtail/unimined/internal/mapping/MappingsProvider.kt
+++ b/src/mapping/kotlin/xyz/wagyourtail/unimined/internal/mapping/MappingsProvider.kt
@@ -321,12 +321,6 @@ open class MappingsProvider(project: Project, minecraft: MinecraftConfig, subKey
 
 
     override fun mojmap() {
-        // 26.1+ is unmapped, so we just use the "official" namespace
-        if (minecraft.minecraftData.mcVersionCompare("1.21.11", minecraft.version) <= 0) {
-            devNamespace("official")
-            return
-        }
-
         mojmapIvy()
         val mappings = when (envType) {
             EnvType.CLIENT, EnvType.JOINED -> "client"

--- a/src/mapping/kotlin/xyz/wagyourtail/unimined/internal/mapping/MappingsProvider.kt
+++ b/src/mapping/kotlin/xyz/wagyourtail/unimined/internal/mapping/MappingsProvider.kt
@@ -321,6 +321,12 @@ open class MappingsProvider(project: Project, minecraft: MinecraftConfig, subKey
 
 
     override fun mojmap() {
+        // 26.1+ is unmapped, so we just use the "official" namespace
+        if (minecraft.minecraftData.mcVersionCompare("1.21.11", minecraft.version) <= 0) {
+            devNamespace("official")
+            return
+        }
+
         mojmapIvy()
         val mappings = when (envType) {
             EnvType.CLIENT, EnvType.JOINED -> "client"

--- a/src/minecraft/kotlin/xyz/wagyourtail/unimined/internal/minecraft/MinecraftProvider.kt
+++ b/src/minecraft/kotlin/xyz/wagyourtail/unimined/internal/minecraft/MinecraftProvider.kt
@@ -85,7 +85,9 @@ open class MinecraftProvider(project: Project, sourceSet: SourceSet) : Minecraft
 
     override val minecraftData = MinecraftDownloader(project, this)
 
-    override val obfuscated = true
+    override val obfuscated: Boolean by FinalizeOnRead(LazyMutable {
+        minecraftData.mcVersionCompare("1.21.11", minecraftData.version) >= 0
+    })
 
     /**
      * Whether to apply fixes to inner classes
@@ -94,7 +96,9 @@ open class MinecraftProvider(project: Project, sourceSet: SourceSet) : Minecraft
      * They don't need fixes, there are no fixes available,
      * and Gradle will throw a cryptic error if you try!
      */
-    open val fixInners = obfuscated
+    open val fixInners: Boolean by LazyMutable {
+        obfuscated
+    }
 
     override val mappings = MappingsProvider(project, this)
 


### PR DESCRIPTION
This PR adds support for 26.1 and newer that is now completely obfuscated.

I tested against 1.21.9-11 and 26.1-snapshot-1 and they all seemed to function fine.

Example of a 26.1 workspace setup for fabric:

```kotlin
unimined.minecraft(sourceSets["main"], false) {
    version("26.1-snapshot-1")

    fabric {
        loader("0.18.1")
    }

     // NOT NEEDED
    //mappings {
    //    mojmap()
    //}
}
```