### PR TITLE
Add support for 26.1 being completely unobfuscated

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -150,11 +150,11 @@ dependencies {
     implementation("com.google.code.gson:gson:2.11.0")
 
     // asm
-    implementation("org.ow2.asm:asm:9.7")
-    implementation("org.ow2.asm:asm-commons:9.7")
-    implementation("org.ow2.asm:asm-tree:9.7")
-    implementation("org.ow2.asm:asm-analysis:9.7")
-    implementation("org.ow2.asm:asm-util:9.7")
+    implementation("org.ow2.asm:asm:9.9")
+    implementation("org.ow2.asm:asm-commons:9.9")
+    implementation("org.ow2.asm:asm-tree:9.9")
+    implementation("org.ow2.asm:asm-analysis:9.9")
+    implementation("org.ow2.asm:asm-util:9.9")
 
     // remapper
     implementation("net.fabricmc:tiny-remapper:0.8.7") {

--- a/src/mapping/kotlin/xyz/wagyourtail/unimined/internal/mapping/MappingsProvider.kt
+++ b/src/mapping/kotlin/xyz/wagyourtail/unimined/internal/mapping/MappingsProvider.kt
@@ -35,10 +35,16 @@ class MappingsProvider(project: Project, minecraft: MinecraftConfig, val mapping
     private var freeze by FinalizeOnWrite(false)
 
     override var devNamespace: Namespace by FinalizeOnRead(LazyMutable {
+        if (minecraft.minecraftData.mcVersionCompare("1.21.11", minecraft.version) <= 0) {
+            return@LazyMutable OFFICIAL
+        }
         getNamespaces().values.firstOrNull { it.named } ?: throw IllegalStateException("No named namespace found in ${getNamespaces().keys}")
     })
 
     override var devFallbackNamespace: Namespace by FinalizeOnRead(LazyMutable {
+        if (minecraft.minecraftData.mcVersionCompare("1.21.11", minecraft.version) <= 0) {
+            return@LazyMutable OFFICIAL
+        }
         devNamespace.targets.firstOrNull { it != OFFICIAL } ?: if (devNamespace.targets.contains(OFFICIAL)) OFFICIAL else throw IllegalStateException("No fallback namespace found")
     })
 
@@ -193,13 +199,6 @@ class MappingsProvider(project: Project, minecraft: MinecraftConfig, val mapping
     }
 
     override fun mojmap(key: String, action: MappingDepConfig.() -> Unit) {
-        // 26.1+ is unmapped, so we just use the "official" namespace
-        if (minecraft.minecraftData.mcVersionCompare("1.21.11", minecraft.version) <= 0) {
-            devNamespace("official")
-            devFallbackNamespace("official")
-            return
-        }
-
         val mapping = when (minecraft.side) {
             EnvType.CLIENT, EnvType.COMBINED -> "client"
             EnvType.SERVER, EnvType.DATAGEN -> "server"

--- a/src/mapping/kotlin/xyz/wagyourtail/unimined/internal/mapping/MappingsProvider.kt
+++ b/src/mapping/kotlin/xyz/wagyourtail/unimined/internal/mapping/MappingsProvider.kt
@@ -193,6 +193,13 @@ class MappingsProvider(project: Project, minecraft: MinecraftConfig, val mapping
     }
 
     override fun mojmap(key: String, action: MappingDepConfig.() -> Unit) {
+        // 26.1+ is unmapped, so we just use the "official" namespace
+        if (minecraft.minecraftData.mcVersionCompare("1.21.11", minecraft.version) <= 0) {
+            devNamespace("official")
+            devFallbackNamespace("official")
+            return
+        }
+
         val mapping = when (minecraft.side) {
             EnvType.CLIENT, EnvType.COMBINED -> "client"
             EnvType.SERVER, EnvType.DATAGEN -> "server"

--- a/src/minecraft/kotlin/xyz/wagyourtail/unimined/internal/minecraft/MinecraftProvider.kt
+++ b/src/minecraft/kotlin/xyz/wagyourtail/unimined/internal/minecraft/MinecraftProvider.kt
@@ -17,7 +17,6 @@ import xyz.wagyourtail.unimined.api.minecraft.EnvType
 import xyz.wagyourtail.unimined.api.minecraft.MinecraftConfig
 import xyz.wagyourtail.unimined.api.minecraft.MinecraftJar
 import xyz.wagyourtail.unimined.api.minecraft.patch.*
-import xyz.wagyourtail.unimined.api.minecraft.patch.ataw.AccessConvert
 import xyz.wagyourtail.unimined.api.minecraft.patch.ataw.AccessTransformerPatcher
 import xyz.wagyourtail.unimined.api.minecraft.patch.ataw.AccessWidenerPatcher
 import xyz.wagyourtail.unimined.api.minecraft.patch.bukkit.CraftbukkitPatcher
@@ -38,7 +37,6 @@ import xyz.wagyourtail.unimined.internal.mapping.MappingsProvider
 import xyz.wagyourtail.unimined.internal.mapping.task.ExportMappingsTaskImpl
 import xyz.wagyourtail.unimined.internal.minecraft.patch.AbstractMinecraftTransformer
 import xyz.wagyourtail.unimined.internal.minecraft.patch.NoTransformMinecraftTransformer
-import xyz.wagyourtail.unimined.internal.minecraft.patch.access.AccessConvertImpl
 import xyz.wagyourtail.unimined.internal.minecraft.patch.access.transformer.AccessTransformerMinecraftTransformer
 import xyz.wagyourtail.unimined.internal.minecraft.patch.access.widener.AccessWidenerMinecraftTransformer
 import xyz.wagyourtail.unimined.internal.minecraft.patch.bukkit.CraftbukkitMinecraftTransformer
@@ -76,7 +74,9 @@ import kotlin.io.path.*
 open class MinecraftProvider(project: Project, sourceSet: SourceSet) : MinecraftConfig(project, sourceSet) {
     override val minecraftData = MinecraftDownloader(project, this)
 
-    override val obfuscated = true
+    override val obfuscated: Boolean by FinalizeOnRead(LazyMutable {
+        minecraftData.mcVersionCompare("1.21.11", minecraftData.version) >= 0
+    })
 
     override val mappings = MappingsProvider(project, this)
 


### PR DESCRIPTION
This PR adds support for 26.1 and newer that is now completely obfuscated.

I had to update ASM as well to support java 25, which is now the required version for MC

I tested against 1.21.9-11 and 26.1-snapshot-1 and they all seemed to function fine.

Example of a 26.1 workspace setup for fabric:

```kotlin
unimined.minecraft(sourceSets["main"], false) {
    version("26.1-snapshot-1")

    fabric {
        loader("0.18.1")
    }

    // NOT NEEDED
    //mappings {
    //    mojmap()
    //}
}
```