### PR TITLE
Fix AccessWideners not finding targets with ClassTweaker

### DIFF
--- a/src/mapping/kotlin/xyz/wagyourtail/unimined/internal/mapping/aw/AccessWidenerApplier.kt
+++ b/src/mapping/kotlin/xyz/wagyourtail/unimined/internal/mapping/aw/AccessWidenerApplier.kt
@@ -97,7 +97,7 @@ object AccessWidenerApplier {
                     logger.debug("Transforming $output with class tweaker $classTweaker and namespace $namespace")
                     baseMinecraft.forEachInZip { path, stream ->
                         if (path.endsWith(".class")) {
-                            val target = path.removeSuffix(".class").replace("/", ".")
+                            val target = path.removeSuffix(".class")
                             if (target in targets) {
                                 try {
                                     logger.debug("Transforming $path")


### PR DESCRIPTION
This fixes `accesswidener did not find the following classes: [net/minecraft/client/gui/GuiTextField, net/minecraft/client/settings/KeyBinding]` errors when using accesswideners with the new ClassTweaker introduced in #176 

`val targets = ct.targets.toMutableSet()` returns the targets as `net/minecraft` instead of `net.minecraft` as the implementation expects, which results in the above error

Edit: This also affects the actual classtweaker format