### PR TITLE
Fix :assemble not remapping the jar file

### DIFF
--- a/src/minecraft/kotlin/xyz/wagyourtail/unimined/internal/minecraft/MinecraftProvider.kt
+++ b/src/minecraft/kotlin/xyz/wagyourtail/unimined/internal/minecraft/MinecraftProvider.kt
@@ -511,7 +511,7 @@ open class MinecraftProvider(project: Project, sourceSet: SourceSet) : Minecraft
                 description = "Remaps $inputTask's output jar"
                 asJar.archiveClassifier.set(classifier)
             }
-            project.tasks.getByName("build").dependsOn("remap" + inputTask.name.capitalized())
+            project.tasks.getByName("assemble").dependsOn("remap" + inputTask.name.capitalized())
         } else {
             project.logger.warn(
                 "[Unimined/Minecraft ${project.path}:${sourceSet.name}] Could not find default task '${inputTaskName.withSourceSet(sourceSet)} for $sourceSet."


### PR DESCRIPTION
Currently when running `gradlew assemble` (build without tests) unimined does not remap the built jar file, leading to it being missing.
By default :build depends on :assemble and :check

Excerpt from `gradlew tasks`
```
Build tasks
-----------
assemble - Assembles the outputs of this project.
build - Assembles and tests this project.
``` 

Since the remapJar task should be run if the project is built, not just when its built&tested (in one run) the task dependency should be changed to :assemble.