### PR TITLE
neo 26.1.1 fix

### DIFF
--- a/src/minecraft/kotlin/xyz/wagyourtail/unimined/internal/minecraft/patch/forge/NeoForgedMinecraftTransformer.kt
+++ b/src/minecraft/kotlin/xyz/wagyourtail/unimined/internal/minecraft/patch/forge/NeoForgedMinecraftTransformer.kt
@@ -41,12 +41,12 @@ open class NeoForgedMinecraftTransformer(project: Project, provider: MinecraftPr
             if (provider.version == "1.20.1") {
                 project.dependencies.create("net.neoforged:forge:${provider.version}-$dep:universal")
             } else {
-                var version = provider.version.removePrefix("1.")
-
-                if (provider.minecraftData.mcVersionCompare(provider.version, "26.1") >= 0) {
-                    version = "${provider.version}.0"
-                } else if (!version.contains(".")) {
-                    version = "$version.0"
+                var version = provider.version
+                if (version.matches(Regex("\\d+\\.\\d+"))) {
+                    version = "${version}.0"
+                }
+                if (provider.minecraftData.mcVersionCompare(version, "26.1") < 0) {
+                    version = version.removePrefix("1.")
                 }
                 project.dependencies.create("net.neoforged:neoforge:$version.$dep:universal")
             }


### PR DESCRIPTION
prev bugged transform:

`26.1.1` -> `26.1.1.0`

existing cases not changed, ex:

`26.1` -> `26.1.0`
`1.21.11` -> `21.11`