### PR TITLE
Indev with Custom Metadata URL Minimal Test Case

### DIFF
--- a/src/api/kotlin/xyz/wagyourtail/unimined/api/minecraft/MinecraftConfig.kt
+++ b/src/api/kotlin/xyz/wagyourtail/unimined/api/minecraft/MinecraftConfig.kt
@@ -218,6 +218,21 @@ abstract class MinecraftConfig(val project: Project, val sourceSet: SourceSet) :
     }
 
     /**
+     * Overrides the launcher manifest to the one provided by OmniArchive,
+     * for access to historical versions that are no longer available in the official Minecraft launcher.
+     */
+    fun omniArchiveManifest() {
+        minecraftData.launcherMetaUrl = project.uri("https://meta.omniarchive.uk/v1/manifest.json")
+    }
+
+    /**
+     * Overrides the launcher manifest to the one provided by Mojang (default).
+     */
+    fun mojangManifestV2() {
+        minecraftData.launcherMetaUrl = project.uri("https://launchermeta.mojang.com/mc/game/version_manifest_v2.json")
+    }
+
+    /**
      * the minecraft version to use
      */
     fun version(version: String) {

--- a/src/api/kotlin/xyz/wagyourtail/unimined/api/minecraft/resolver/MinecraftData.kt
+++ b/src/api/kotlin/xyz/wagyourtail/unimined/api/minecraft/resolver/MinecraftData.kt
@@ -10,9 +10,22 @@ abstract class MinecraftData {
     @get:ApiStatus.Internal
     abstract val mcVersionFolder: Path
 
+    /**
+     * The location of the JSON file that lists available versions.
+     *
+     * **Resetting this may cause caching errors.**
+     *
+     * @sample xyz.wagyourtail.unimined.api.minecraft.MinecraftConfig.MOJANG_MANIFEST_V2
+     * @sample xyz.wagyourtail.unimined.api.minecraft.MinecraftConfig.OMNIARCHIVE_MANIFEST
+     */
     @set:ApiStatus.Experimental
     abstract var launcherMetaUrl: URI?
 
+    /**
+     * The location of the JSON file for the target version.
+     *
+     * **Resetting this may cause caching errors.**
+     */
     @set:ApiStatus.Experimental
     abstract var metadataURL: URI
 

--- a/src/minecraft/kotlin/xyz/wagyourtail/unimined/internal/minecraft/resolver/MinecraftDownloader.kt
+++ b/src/minecraft/kotlin/xyz/wagyourtail/unimined/internal/minecraft/resolver/MinecraftDownloader.kt
@@ -20,6 +20,7 @@ import java.nio.file.Path
 import java.nio.file.StandardCopyOption
 import java.util.zip.ZipOutputStream
 import kotlin.io.path.*
+import kotlin.time.Duration.Companion.minutes
 import kotlin.time.Duration.Companion.seconds
 
 open class MinecraftDownloader(val project: Project, open val provider: MinecraftProvider) : MinecraftData() {
@@ -110,12 +111,13 @@ open class MinecraftDownloader(val project: Project, open val provider: Minecraf
 
         project.logger.lifecycle("[Unimined/MinecraftDownloader] retrieving version metadata")
         project.logger.info("[Unimined/MinecraftDownloader]     metadata url $metadataURL")
-        if (!versionJson.exists() || project.unimined.forceReload) {
+        if ((metadataURL.scheme != "file" && !versionJson.exists() || project.unimined.forceReload)) {
             versionJson.parent.createDirectories()
 
             project.cachingDownload(
                 metadataURL,
-                cachePath = versionJson
+                cachePath = versionJson,
+                expireTime = 1.minutes
             )
 
         }

--- a/src/minecraft/kotlin/xyz/wagyourtail/unimined/internal/minecraft/resolver/VersionData.kt
+++ b/src/minecraft/kotlin/xyz/wagyourtail/unimined/internal/minecraft/resolver/VersionData.kt
@@ -177,7 +177,7 @@ fun applyGameArgs(
 
 fun parseVersionData(json: JsonObject): VersionData {
     return VersionData(
-        json.get("id").asString,
+        requireNotNull(json.get("id")?.asString, { "version id not found" }),
         json.get("type")?.asString,
         json.get("time")?.asString?.let {
             DateTimeComponents.Formats.ISO_DATE_TIME_OFFSET.parse(it).toLocalDateTime().toJavaLocalDateTime()

--- a/src/test/kotlin/xyz/wagyourtail/unimined/test/integration/In_20091223_1459Test.kt
+++ b/src/test/kotlin/xyz/wagyourtail/unimined/test/integration/In_20091223_1459Test.kt
@@ -1,0 +1,29 @@
+package xyz.wagyourtail.unimined.test.integration
+
+import org.gradle.testkit.runner.TaskOutcome
+import org.gradle.testkit.runner.UnexpectedBuildFailure
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.MethodSource
+import xyz.wagyourtail.unimined.util.runTestProject
+
+class In_20091223_1459Test {
+    @ParameterizedTest
+    @MethodSource("xyz.wagyourtail.unimined.util.IntegrationTestUtils#versions")
+    fun test_indev_20091223_1459(gradleVersion: String) {
+        try {
+            val result = runTestProject("in-20091223-1459", gradleVersion)
+
+            try {
+                result.task(":build")?.outcome?.let {
+                    if (it != TaskOutcome.SUCCESS) throw Exception("build failed")
+                } ?: throw Exception("build failed")
+            } catch (e: Exception) {
+                println(result.output)
+                throw Exception(e)
+            }
+        } catch (e: UnexpectedBuildFailure) {
+            println(e)
+            throw Exception("build failed", e)
+        }
+    }
+}

--- a/testing/in-20091223-1459/build.gradle
+++ b/testing/in-20091223-1459/build.gradle
@@ -6,8 +6,7 @@ plugins {
 unimined.useGlobalCache = false
 
 unimined.minecraft {
-	minecraftData.metadataURL = uri("https://meta.omniarchive.uk/versions/v1/in-20091223-1459.json")
-
+    omniArchiveManifest()
     version("in-20091223-1459")
     side("client")
 

--- a/testing/in-20091223-1459/build.gradle
+++ b/testing/in-20091223-1459/build.gradle
@@ -1,0 +1,19 @@
+plugins {
+    id 'xyz.wagyourtail.unimined' // version '4.2.0'
+}
+
+// this is just here so we can test the outputs easier and clean between tests
+unimined.useGlobalCache = false
+
+unimined.minecraft {
+	minecraftData.metadataURL = uri("https://meta.omniarchive.uk/versions/v1/in-20091223-1459.json")
+
+    version("in-20091223-1459")
+    side("client")
+
+    mappings {
+        ornitheGenVersion = 2
+        calamus()
+        feather(1)
+    }
+}

--- a/testing/in-20091223-1459/gradle.properties
+++ b/testing/in-20091223-1459/gradle.properties
@@ -1,0 +1,1 @@
+org.gradle.jvmargs=-Xmx3G

--- a/testing/in-20091223-1459/settings.gradle
+++ b/testing/in-20091223-1459/settings.gradle
@@ -1,0 +1,34 @@
+pluginManagement {
+    repositories {
+        mavenCentral()
+        maven {
+            url = "https://maven.neoforged.net/releases"
+        }
+        maven {
+            url = "https://maven.minecraftforge.net/"
+        }
+        maven {
+            url = "https://maven.fabricmc.net/"
+        }
+        maven {
+            url = "https://maven.wagyourtail.xyz/releases"
+        }
+        maven {
+            url = "https://maven.wagyourtail.xyz/snapshots"
+        }
+        gradlePluginPortal() {
+            content {
+                excludeGroup("org.apache.logging.log4j")
+            }
+        }
+    }
+}
+
+plugins {
+    id("org.gradle.toolchains.foojay-resolver-convention") version "0.8.0"
+}
+
+// so we can use the unimined directly provided by the super project
+includeBuild('../../')
+
+rootProject.name = 'in-20091223-1459'


### PR DESCRIPTION
This serves as a test of overriding the launcher metadata, and as a future example to myself and others who want to use versions that aren't in the official launcher as well.

~~I should also add a test for the custom manifest field but I don't know how exactly I should make the test, or even how to do use it myself yet.~~

I added a helper function to override the launcher manifest. And to prevent odd errors from occurring, I made version metadata expire after one minute so it will be re-downloaded every-so-often and prevent hair-tearing.
I also noticed that the guard to prevent local files from attempting to download was missing from the version metadata, so I fixed that.