### PR TITLE
Backport 26.1 support to Unimined 1.3

### DIFF
--- a/src/minecraft/kotlin/xyz/wagyourtail/unimined/internal/minecraft/MinecraftProvider.kt
+++ b/src/minecraft/kotlin/xyz/wagyourtail/unimined/internal/minecraft/MinecraftProvider.kt
@@ -111,10 +111,6 @@ open class MinecraftProvider(project: Project, sourceSet: SourceSet) : Minecraft
         it.setTransitive(false)
     }
 
-    init {
-        replaceLibraryVersion("ca\\.weblite", "java-objc-bridge", "natives-osx") { null }
-    }
-
     override fun from(project: Project, sourceSet: SourceSet) {
         val delegate = MinecraftProvider::class.getField("mcPatcher")!!.getDelegate(this) as FinalizeOnRead<FinalizeOnWrite<MinecraftPatcher>>
         if (delegate.finalized || (delegate.value as FinalizeOnWrite<MinecraftPatcher>).finalized) {

--- a/src/minecraft/kotlin/xyz/wagyourtail/unimined/internal/minecraft/patch/AbstractMinecraftTransformer.kt
+++ b/src/minecraft/kotlin/xyz/wagyourtail/unimined/internal/minecraft/patch/AbstractMinecraftTransformer.kt
@@ -248,6 +248,7 @@ abstract class AbstractMinecraftTransformer protected constructor(
         "META-INF/**",
         "net/minecraft/**",
         "com/mojang/blaze3d/**",
+        "com/mojang/math/**",
         "com/mojang/realmsclient/**",
         "paulscode/sound/**",
         "com/jcraft/**"

--- a/src/minecraft/kotlin/xyz/wagyourtail/unimined/internal/minecraft/patch/access/transformer/AccessTransformerMinecraftTransformer.kt
+++ b/src/minecraft/kotlin/xyz/wagyourtail/unimined/internal/minecraft/patch/access/transformer/AccessTransformerMinecraftTransformer.kt
@@ -29,7 +29,9 @@ interface AccessTransformerMinecraftTransformer : AccessTransformerPatcher, Acce
 
     companion object {
         fun getDefaultDependency(project: Project, provider: MinecraftProvider): Dependency {
-            return if (provider.minecraftData.metadata.javaVersion >= JavaVersion.VERSION_21)
+            return if (provider.minecraftData.metadata.javaVersion >= JavaVersion.VERSION_25)
+                project.dependencies.create("net.neoforged.accesstransformers:at-cli:13.0.3")
+            else if (provider.minecraftData.metadata.javaVersion >= JavaVersion.VERSION_21)
                 project.dependencies.create("net.neoforged.accesstransformers:at-cli:11.0.2")
             else
                 project.dependencies.create("net.neoforged:accesstransformers:9.0.3")

--- a/src/minecraft/kotlin/xyz/wagyourtail/unimined/internal/minecraft/patch/forge/NeoForgedMinecraftTransformer.kt
+++ b/src/minecraft/kotlin/xyz/wagyourtail/unimined/internal/minecraft/patch/forge/NeoForgedMinecraftTransformer.kt
@@ -38,9 +38,12 @@ open class NeoForgedMinecraftTransformer(project: Project, provider: MinecraftPr
             if (provider.version == "1.20.1") {
                 project.dependencies.create("net.neoforged:forge:${provider.version}-$dep:universal")
             } else {
-                var version = provider.version.removePrefix("1.")
-                if (!version.contains(".")) {
+                var version = provider.version
+                if (version.matches(Regex("\\d+\\.\\d+"))) {
                     version = "$version.0"
+                }
+                if (provider.minecraftData.mcVersionCompare(version, "26.1") < 0) {
+                    version = version.removePrefix("1.")
                 }
                 project.dependencies.create("net.neoforged:neoforge:$version.$dep:universal")
             }

--- a/src/minecraft/kotlin/xyz/wagyourtail/unimined/internal/minecraft/patch/forge/NeoForgedMinecraftTransformer.kt
+++ b/src/minecraft/kotlin/xyz/wagyourtail/unimined/internal/minecraft/patch/forge/NeoForgedMinecraftTransformer.kt
@@ -106,19 +106,19 @@ open class NeoForgedMinecraftTransformer(project: Project, provider: MinecraftPr
             manifest.mainAttributes[Attributes.Name("Minecraft-Dists")] = provider.side.classifier ?: "client server"
 
             if (provider.side == EnvType.COMBINED && baseMinecraftServer != null) {
-                val mappings = parent.provider.mappings.resolveMappingTree()
-                val officialNamespace = mappings.getNamespaceId("official")
-                val namedNamespace = mappings.getNamespaceId(provider.mappings.devNamespace.name)
-
                 val clientEntries = baseMinecraftClient.path.readZipContents().toSet()
                 val serverEntries = baseMinecraftServer.path.readZipContents().toSet()
 
-                fun mapEntry(name: String): String {
-                    if (!name.endsWith(".class")) {
-                        return name
+                val mapEntry: (String) -> String = if (provider.obfuscated) {
+                    val mappings = parent.provider.mappings.resolveMappingTree()
+                    val officialNamespace = mappings.getNamespaceId("official")
+                    val namedNamespace = mappings.getNamespaceId(provider.mappings.devNamespace.name);
+                    { name ->
+                        if (!name.endsWith(".class")) name
+                        else mappings.getClass(name.substring(0, name.length - 6), officialNamespace).getName(namedNamespace) + ".class"
                     }
-
-                    return mappings.getClass(name.substring(0, name.length - 6), officialNamespace).getName(namedNamespace) + ".class"
+                } else {
+                    { it }
                 }
 
                 for (clientEntry in clientEntries) {

--- a/src/minecraft/kotlin/xyz/wagyourtail/unimined/internal/minecraft/patch/forge/fg3/FG3MinecraftTransformer.kt
+++ b/src/minecraft/kotlin/xyz/wagyourtail/unimined/internal/minecraft/patch/forge/fg3/FG3MinecraftTransformer.kt
@@ -43,6 +43,10 @@ open class FG3MinecraftTransformer(project: Project, val parent: ForgeLikeMinecr
     project, parent.provider, jarModProvider = "forge", providerName = "${parent.providerName}-FG3"
 ) {
 
+    val isModernNeo by lazy {
+        parent is NeoForgedMinecraftTransformer && !provider.obfuscated
+    }
+
     val useUnionRelauncher by lazy {
         if (parent is MinecraftForgeMinecraftTransformer) {
             parent.useUnionRelaunch
@@ -78,7 +82,9 @@ open class FG3MinecraftTransformer(project: Project, val parent: ForgeLikeMinecr
         }
 
     override val prodNamespace by lazy {
-        if (userdevCfg["mcp"].asString.contains("neoform") || provider.minecraftData.mcVersionCompare(provider.version, "1.20.5") >= 0) {
+        if (!provider.obfuscated) {
+            provider.mappings.getNamespace("official")
+        } else if (userdevCfg["mcp"].asString.contains("neoform") || provider.minecraftData.mcVersionCompare(provider.version, "1.20.5") >= 0) {
             provider.mappings.getNamespace("mojmap")
         } else {
             provider.mappings.getNamespace("searge")
@@ -117,7 +123,7 @@ open class FG3MinecraftTransformer(project: Project, val parent: ForgeLikeMinecr
     }
 
     open val obfNamespace by lazy {
-        if (userdevCfg["notchObf"]?.asBoolean == true) "official"
+        if (userdevCfg["notchObf"]?.asBoolean == true || !provider.obfuscated) "official"
         else if (userdevCfg["mcp"].asString.contains("neoform")) "mojmap"
         else "searge"
     }
@@ -162,6 +168,7 @@ open class FG3MinecraftTransformer(project: Project, val parent: ForgeLikeMinecr
 
     override fun beforeMappingsResolve() {
         project.logger.info("[Unimined/ForgeTransformer] FG3: beforeMappingsResolve")
+        if (!provider.obfuscated) return
         provider.mappings {
             if (obfNamespace == "mojmap") {
                 mojmap()
@@ -214,7 +221,7 @@ open class FG3MinecraftTransformer(project: Project, val parent: ForgeLikeMinecr
             val mainClass = get("main").asString
             if (!mainClass.startsWith("net.minecraftforge.legacydev")) {
                 project.logger.info("[Unimined/ForgeTransformer] Inserting mcp mappings")
-                if (obfNamespace != "mojmap") {
+                if (obfNamespace != "mojmap" && provider.obfuscated) {
                     provider.minecraftLibraries.dependencies.add(
                         project.dependencies.create(project.files(parent.srgToMCPAsMCP))
                     )
@@ -271,6 +278,8 @@ open class FG3MinecraftTransformer(project: Project, val parent: ForgeLikeMinecr
         }
         if (userdevCfg["notchObf"]?.asBoolean == true) {
             executeMcp("merge", output.path, EnvType.COMBINED)
+        } else if (isModernNeo) {
+            executeMcp("preProcessJar", output.path, EnvType.COMBINED)
         } else {
             executeMcp("rename", output.path, EnvType.COMBINED)
         }
@@ -424,6 +433,9 @@ open class FG3MinecraftTransformer(project: Project, val parent: ForgeLikeMinecr
         }
         //   shade in forge jar
         val shadedForge = super.transform(patchedMC)
+        if (isModernNeo) {
+            removeMinecraftResourceMarkers(shadedForge.path)
+        }
         return if (userdevCfg["notchObf"]?.asBoolean == true) {
             provider.minecraftRemapper.provide(shadedForge, provider.mappings.getNamespace("searge"), provider.mappings.OFFICIAL)
         } else {
@@ -643,7 +655,9 @@ open class FG3MinecraftTransformer(project: Project, val parent: ForgeLikeMinecr
     }
 
     private fun fixForge(baseMinecraft: MinecraftJar): MinecraftJar {
-        if (!baseMinecraft.patches.contains("fixForge") && baseMinecraft.mappingNamespace != provider.mappings.OFFICIAL) {
+        if (!baseMinecraft.patches.contains("fixForge") &&
+            (!provider.obfuscated || baseMinecraft.mappingNamespace != provider.mappings.OFFICIAL)
+        ) {
             val target = MinecraftJar(
                 baseMinecraft,
                 patches = baseMinecraft.patches + "fixForge",
@@ -657,6 +671,7 @@ open class FG3MinecraftTransformer(project: Project, val parent: ForgeLikeMinecr
             try {
                 target.path.openZipFileSystem(mapOf("mutable" to true)).use { out ->
                     out.getPath("binpatches.pack.lzma").deleteIfExists()
+                    out.getPath("binpatches-joined.lzma").deleteIfExists()
                 }
             } catch (e: Throwable) {
                 target.path.deleteIfExists()
@@ -665,6 +680,20 @@ open class FG3MinecraftTransformer(project: Project, val parent: ForgeLikeMinecr
             return target
         }
         return baseMinecraft
+    }
+
+    private fun removeMinecraftResourceMarkers(jarPath: Path) {
+        val markers = listOf("data/.mcassetsroot", "assets/.mcassetsroot")
+        val hasAny = jarPath.openZipFileSystem().use { fs ->
+            markers.any { Files.exists(fs.getPath(it)) }
+        }
+        if (!hasAny) return
+        project.logger.info("[Unimined/ForgeTransformer] Removing Minecraft asset-root markers from ${jarPath.fileName} to fix NeoForge GameLocator conflict")
+        jarPath.openZipFileSystem(mapOf("mutable" to true)).use { fs ->
+            for (marker in markers) {
+                Files.deleteIfExists(fs.getPath(marker))
+            }
+        }
     }
 
     override fun createSourcesJar(

--- a/src/minecraft/kotlin/xyz/wagyourtail/unimined/internal/minecraft/patch/forge/fg3/mcpconfig/McpConfigData.kt
+++ b/src/minecraft/kotlin/xyz/wagyourtail/unimined/internal/minecraft/patch/forge/fg3/mcpconfig/McpConfigData.kt
@@ -12,7 +12,19 @@ data class McpConfigData(
 ) {
     companion object {
         fun fromJson(json: JsonObject): McpConfigData {
-            val mappingsPath = json.getAsJsonObject("data")["mappings"].asString
+            val specVersion = if (json.has("spec")) json.getAsJsonPrimitive("spec").asInt else 0
+            val isSpec6 = specVersion >= 6
+
+            val dataObj = json.getAsJsonObject("data")
+            val mappingsValue = dataObj?.get("mappings")
+            val mappingsPath = when {
+                mappingsValue == null -> ""
+                mappingsValue.isJsonObject ->
+                    mappingsValue.asJsonObject["joined"]?.asString
+                        ?: mappingsValue.asJsonObject.entrySet().firstOrNull()?.value?.asString ?: ""
+                else -> mappingsValue.asString
+            }
+
             val official = json.has("official") && json.getAsJsonPrimitive("official").asBoolean
             val stepsJson = json.getAsJsonObject("steps")
             val stepsBuilder = ImmutableMap.builder<String, List<McpConfigStep>>()
@@ -26,7 +38,7 @@ data class McpConfigData(
             val functionsJson = json.getAsJsonObject("functions")
             val functionsBuilder = ImmutableMap.builder<String, McpConfigFunction>()
             for (key in functionsJson.keySet()) {
-                functionsBuilder.put(key, McpConfigFunction.fromJson(functionsJson.getAsJsonObject(key)))
+                functionsBuilder.put(key, McpConfigFunction.fromJson(functionsJson.getAsJsonObject(key), isSpec6))
             }
             return McpConfigData(mappingsPath, official, stepsBuilder.build(), functionsBuilder.build())
         }

--- a/src/minecraft/kotlin/xyz/wagyourtail/unimined/internal/minecraft/patch/forge/fg3/mcpconfig/McpConfigFunction.kt
+++ b/src/minecraft/kotlin/xyz/wagyourtail/unimined/internal/minecraft/patch/forge/fg3/mcpconfig/McpConfigFunction.kt
@@ -4,7 +4,9 @@ import com.google.gson.JsonArray
 import com.google.gson.JsonObject
 
 data class McpConfigFunction(
-    val version: String,
+    val version: String?,
+    val classpath: List<String>?,
+    val mainClass: String?,
     val args: List<ConfigValue>,
     val jvmArgs: List<ConfigValue>,
     val repo: String
@@ -15,12 +17,19 @@ data class McpConfigFunction(
         private const val JVM_ARGS_KEY = "jvmargs"
         private const val REPO_KEY = "repo"
 
-        fun fromJson(json: JsonObject): McpConfigFunction {
-            val version = json[VERSION_KEY].asString
+        fun fromJson(json: JsonObject, isSpec6: Boolean = false): McpConfigFunction {
             val args = if (json.has(ARGS_KEY)) configValuesFromJson(json.getAsJsonArray(ARGS_KEY)) else listOf()
             val jvmArgs = if (json.has(JVM_ARGS_KEY)) configValuesFromJson(json.getAsJsonArray(JVM_ARGS_KEY)) else listOf()
-            val repo = if (json[REPO_KEY].isJsonNull) "https://maven.neoforged.net/releases/" else json[REPO_KEY].asString
-            return McpConfigFunction(version, args, jvmArgs, repo)
+            return if (isSpec6) {
+                val classpath = json.getAsJsonArray("classpath")?.map { it.asString } ?: listOf()
+                val mainClass = json["main_class"]?.asString
+                McpConfigFunction(null, classpath, mainClass, args, jvmArgs, "")
+            } else {
+                val version = json[VERSION_KEY].asString
+                val repoEl = json[REPO_KEY]
+                val repo = if (repoEl == null || repoEl.isJsonNull) "https://maven.neoforged.net/releases/" else repoEl.asString
+                McpConfigFunction(version, null, null, args, jvmArgs, repo)
+            }
         }
 
         private fun configValuesFromJson(json: JsonArray): List<ConfigValue> {
@@ -29,7 +38,8 @@ data class McpConfigFunction(
     }
 
     fun getDownloadUrl(): String {
-        val parts = version.split(":".toRegex()).dropLastWhile { it.isEmpty() }.toTypedArray()
+        val v = version ?: error("getDownloadUrl() called on spec 6+ function without version")
+        val parts = v.split(":".toRegex()).dropLastWhile { it.isEmpty() }.toTypedArray()
         val builder = StringBuilder()
         builder.append(repo)
         // Group:

--- a/src/minecraft/kotlin/xyz/wagyourtail/unimined/internal/minecraft/patch/forge/fg3/mcpconfig/McpExecutor.kt
+++ b/src/minecraft/kotlin/xyz/wagyourtail/unimined/internal/minecraft/patch/forge/fg3/mcpconfig/McpExecutor.kt
@@ -215,6 +215,14 @@ data class McpExecutor(
             SubprocessExecutor.exec(project, configurator).rethrowFailure().assertNormalExitValue()
         }
 
+        override fun resolveCoordinates(coords: List<String>): List<Path> {
+            val config = project.configurations.detachedConfiguration()
+            for (coord in coords) {
+                config.dependencies.add(project.dependencies.create(coord))
+            }
+            return config.resolve().map { it.toPath() }
+        }
+
         override val minecraftLibraries: Set<File>
             get() = provider.minecraftLibraries.resolve()
     }

--- a/src/minecraft/kotlin/xyz/wagyourtail/unimined/internal/minecraft/patch/forge/fg3/mcpconfig/StepLogic.kt
+++ b/src/minecraft/kotlin/xyz/wagyourtail/unimined/internal/minecraft/patch/forge/fg3/mcpconfig/StepLogic.kt
@@ -40,6 +40,7 @@ interface StepLogic {
         @Throws(IOException::class)
         fun download(url: String): Path
         fun javaexec(configurator: Action<in JavaExecSpec>)
+        fun resolveCoordinates(coords: List<String>): List<Path>
         val minecraftLibraries: Set<File>
 
         fun resolve(configValues: List<ConfigValue>): List<String> {
@@ -51,27 +52,42 @@ interface StepLogic {
         @Throws(IOException::class)
         override fun execute(context: ExecutionContext) {
             context.setOutput("output")
-            val jar: Path = context.download(function.getDownloadUrl())
-            var mainClass: String
-            try {
-                JarFile(jar.toFile()).use { jarFile ->
-                    mainClass = jarFile.manifest
-                        .mainAttributes
-                        .getValue(Attributes.Name.MAIN_CLASS)
+            if (function.classpath != null) {
+                // spec 6+: resolve via Gradle, use explicit mainClass if provided
+                val jars = context.resolveCoordinates(function.classpath)
+                val mainClass = function.mainClass ?: JarFile(jars.first().toFile()).use { jf ->
+                    jf.manifest.mainAttributes.getValue(Attributes.Name.MAIN_CLASS)
+                        ?: error("No Main-Class in manifest of ${jars.first()}")
                 }
-            } catch (e: IOException) {
-                throw IOException("Could not determine main class for " + jar.toAbsolutePath(), e)
+                context.javaexec(Action { spec: JavaExecSpec ->
+                    spec.classpath(jars.map { it.toFile() })
+                    spec.mainClass.set(mainClass)
+                    spec.args(context.resolve(function.args))
+                    spec.jvmArgs(context.resolve(function.jvmArgs))
+                })
+            } else {
+                val jar: Path = context.download(function.getDownloadUrl())
+                var mainClass: String
+                try {
+                    JarFile(jar.toFile()).use { jarFile ->
+                        mainClass = jarFile.manifest
+                            .mainAttributes
+                            .getValue(Attributes.Name.MAIN_CLASS)
+                    }
+                } catch (e: IOException) {
+                    throw IOException("Could not determine main class for " + jar.toAbsolutePath(), e)
+                }
+                context.javaexec(Action { spec: JavaExecSpec ->
+                    spec.classpath(jar)
+                    spec.mainClass.set(mainClass)
+                    spec.args(context.resolve(function.args))
+                    spec.jvmArgs(context.resolve(function.jvmArgs))
+                })
             }
-            context.javaexec(Action { spec: JavaExecSpec ->
-                spec.classpath(jar)
-                spec.mainClass.set(mainClass)
-                spec.args(context.resolve(function.args))
-                spec.jvmArgs(context.resolve(function.jvmArgs))
-            })
         }
 
         override fun getDisplayName(stepName: String): String {
-            return stepName + " with " + function.version
+            return stepName + " with " + (function.version ?: function.classpath?.firstOrNull() ?: "unknown")
         }
     }
 


### PR DESCRIPTION
This PR backports the changes needed to run NeoForge & Fabric 26.1 in dev on Unimined 1.3. This work is a direct derivative of the following PRs: #185, #190, #194, #199 with adjustments for differences like the mapping library.

The changes in this PR were co-authored by Claude Sonnet 4.6. The whole diff has been human-reviewed, tweaked in places, and tested with a modified version of the 1.21 test project (switched Java version to 25 and removed `mappings` block).